### PR TITLE
Add DSP subscription plan warning box

### DIFF
--- a/src/assets/images/StarFillIcon.tsx
+++ b/src/assets/images/StarFillIcon.tsx
@@ -23,22 +23,3 @@ const StarFillIcon = createSvgIcon(
   "Star"
 );
 export default StarFillIcon;
-<svg
-  width="24"
-  height="24"
-  viewBox="0 0 24 24"
-  fill="none"
-  xmlns="http://www.w3.org/2000/svg"
->
-  <g clipPath="url(#clip0_4_3236)">
-    <path
-      d="M12 0.5L16.226 6.683L23.413 8.792L18.838 14.722L19.053 22.208L12 19.69L4.94701 22.208L5.16201 14.722L0.587006 8.792L7.77401 6.683L12 0.5Z"
-      fill="white"
-    />
-  </g>
-  <defs>
-    <clipPath id="clip0_4_3236">
-      <rect width="24" height="24" fill="white" />
-    </clipPath>
-  </defs>
-</svg>;

--- a/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -79,6 +79,9 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
   const handlePricingPlanClose = () => {
     setIsPricingPlansOpen(false);
   };
+  const handlePricingPlanOpen = () => {
+    setIsPricingPlansOpen(true);
+  };
 
   useEffectAfterMount(() => {
     if (!isPricingPlansOpen && isArtistPricePlanSelected) {
@@ -261,8 +264,36 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
             ref={ descriptionRef }
           />
 
-          <Stack mt={ 5 } spacing={ 5 }>
-            <Box>
+          <Stack spacing={ 3 }>
+            <Stack spacing={ 1.5 }>
+              { !isArtistPricePlanSelected && (
+                <Alert
+                  severity="warning"
+                  action={
+                    <Button
+                      aria-label="show pricing plans"
+                      variant="outlined"
+                      color="yellow"
+                      onClick={ handlePricingPlanOpen }
+                      sx={ { textTransform: "none" } }
+                    >
+                      See plans
+                    </Button>
+                  }
+                >
+                  <Typography mb={ 0.5 } color="yellow">
+                    You need a subscription plan in order to mint your songs
+                  </Typography>
+                  <Typography
+                    color="yellow"
+                    fontWeight={ 400 }
+                    variant="subtitle1"
+                  >
+                    Without one, you can still upload a song but it won&apos;t
+                    be minted nor distributed.
+                  </Typography>
+                </Alert>
+              ) }
               <Box
                 ref={ ownersRef }
                 sx={ {
@@ -281,8 +312,7 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
                     "purchase, and enables royalty distribution to your account."
                   }
                   onClick={ () => {
-                    !isArtistPricePlanSelected &&
-                      setIsPricingPlansOpen(!values.isMinting);
+                    if (!isArtistPricePlanSelected) handlePricingPlanOpen();
                   } }
                 />
 
@@ -303,14 +333,14 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
                   <ErrorMessage>{ errors.owners as string }</ErrorMessage>
                 </Box>
               ) }
-            </Box>
+            </Stack>
 
             { isMintingVisible && !isVerified && (
               <Alert
                 severity="warning"
                 action={
                   <Button
-                    aria-label="close"
+                    aria-label="verify profile"
                     variant="outlined"
                     color="yellow"
                     onClick={ handleVerifyProfile }
@@ -320,7 +350,9 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
                   </Button>
                 }
               >
-                <Typography color="yellow">Verify your profile</Typography>
+                <Typography mb={ 0.5 } color="yellow">
+                  Verify your profile
+                </Typography>
                 <Typography color="yellow" fontWeight={ 400 } variant="subtitle1">
                   Profile verification is required to mint. Please verify your
                   profile.
@@ -334,7 +366,7 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
                 severity="warning"
                 action={
                   <Button
-                    aria-label="close"
+                    aria-label="connect wallet"
                     variant="outlined"
                     color="yellow"
                     onClick={ () => {
@@ -346,7 +378,9 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
                   </Button>
                 }
               >
-                <Typography color="yellow">Connect a wallet</Typography>
+                <Typography mb={ 0.5 } color="yellow">
+                  Connect a wallet
+                </Typography>
                 <Typography color="yellow" fontWeight={ 400 } variant="subtitle1">
                   To continue, please connect a wallet.
                 </Typography>


### PR DESCRIPTION
Adds:
- Warning/Alert box for users that aren't part of a subscription plan which opens the DSP pricing plan Dialog when `See plans` is  clicked

Refactor:
- Update UI spacing to match Figma

Fixes:
- Remove superfluous svg code that was in the `StarFillIcon.tsx` asset

[demo_NEWM-Studio_DSP-warning-box.webm](https://github.com/projectNEWM/newm-artist-portal/assets/86050631/8a67f19c-4462-49d3-827c-8e41285eceb0)
