### PR TITLE
Save DSP pricing plan selection to endpoint

### DIFF
--- a/apps/studio/src/common/mockConstants/mockSession.ts
+++ b/apps/studio/src/common/mockConstants/mockSession.ts
@@ -3,7 +3,6 @@ import { PersistPartial } from "redux-persist/lib/persistReducer";
 
 export const mockSession: SessionState & PersistPartial = {
   _persist: { version: 0, rehydrated: false },
-  isArtistPricePlanSelected: false,
   isLoggedIn: true,
   verificationPingStartedAt: undefined,
 };

--- a/apps/studio/src/components/dspPricing/PricingPlanOption.tsx
+++ b/apps/studio/src/components/dspPricing/PricingPlanOption.tsx
@@ -3,8 +3,6 @@ import { Box, Divider, Stack } from "@mui/material";
 import { Button, Typography } from "@newm-web/elements";
 import { JSX } from "react";
 import theme from "@newm-web/theme";
-import { useAppDispatch } from "../../common";
-import { setIsArtistPricePlanSelected } from "../../modules/session";
 import { pricingPlanData } from "../../assets";
 
 interface PricingPlanOptionProps {
@@ -22,6 +20,7 @@ interface PricingPlanOptionProps {
   readonly buttonText: string;
   readonly buttonType: string;
   handleOptionClick: () => void;
+  hasOptionBeenSelected: boolean;
 }
 
 const PricingPlanOption = ({
@@ -36,9 +35,8 @@ const PricingPlanOption = ({
   buttonText,
   buttonType,
   handleOptionClick,
+  hasOptionBeenSelected,
 }: PricingPlanOptionProps) => {
-  const dispatch = useAppDispatch();
-
   const criterionIcon = (includedInPlan: boolean) => {
     if (includedInPlan) {
       return <Check sx={{ color: theme.colors.green, fontSize: iconPxSize }} />;
@@ -166,19 +164,14 @@ const PricingPlanOption = ({
         <Divider sx={{ width: "70%" }} color={theme.colors.grey400} />
 
         {buttonType === "primary" ? (
-          <Button
-            onClick={() => {
-              dispatch(setIsArtistPricePlanSelected(true));
-              handleOptionClick();
-            }}
-          >
+          <Button onClick={handleOptionClick} isLoading={hasOptionBeenSelected}>
             {buttonText}
           </Button>
         ) : (
           <Button
             variant={"secondary"}
             color="music"
-            disabled={!active}
+            disabled={!active || hasOptionBeenSelected}
             onClick={handleOptionClick}
           >
             {buttonText}

--- a/apps/studio/src/components/dspPricing/PricingPlansDialog.tsx
+++ b/apps/studio/src/components/dspPricing/PricingPlansDialog.tsx
@@ -7,6 +7,7 @@ import { pricingPlanData } from "../../assets";
 import PricingPlanOption from "./PricingPlanOption";
 import { LeafFillIcon, SeedlingFillIcon, StarFillIcon } from "@newm-web/assets";
 import { useGetMintSongEstimateQuery } from "../../modules/song";
+import { useUpdateProfileThunk } from "../../modules/session";
 
 const ICON_SIZE = "20px";
 
@@ -28,6 +29,18 @@ interface PricingPlansDialogProps {
 }
 
 const PricingPlansDialog = ({ handleClose, open }: PricingPlansDialogProps) => {
+  const [updateProfile, { isLoading }] = useUpdateProfileThunk();
+
+  const handleOptionClick = (optionClicked: string) => {
+    if (optionClicked === "artist") {
+      updateProfile({ dspPlanSubscribed: true }).then(() => {
+        handleClose();
+      });
+    } else {
+      handleClose();
+    }
+  };
+
   const { data: { dspPriceAda, dspPriceUsd } = {} } =
     useGetMintSongEstimateQuery({
       collaborators: 1,
@@ -100,7 +113,7 @@ const PricingPlansDialog = ({ handleClose, open }: PricingPlansDialogProps) => {
                     ? `(~${Number(dspPriceAda).toFixed(2)}₳/RELEASE)`
                     : undefined
                 }
-                handleOptionClick={handleClose}
+                handleOptionClick={() => handleOptionClick(pricingPlan.id)}
                 key={pricingPlan.id}
                 planIcon={{
                   iconPxSize: ICON_SIZE,
@@ -111,6 +124,7 @@ const PricingPlansDialog = ({ handleClose, open }: PricingPlansDialogProps) => {
                     ? `$${Number(dspPriceUsd).toFixed(2)}/RELEASE`
                     : pricingPlan.pricing
                 }
+                hasOptionBeenSelected={isLoading}
               />
             );
           })}

--- a/apps/studio/src/modules/session/api.ts
+++ b/apps/studio/src/modules/session/api.ts
@@ -45,6 +45,7 @@ export const emptyProfile: Profile = {
   companyLogoUrl: "",
   companyName: "",
   walletAddress: "",
+  dspPlanSubscribed: false,
 };
 
 export const extendedApi = newmApi.injectEndpoints({

--- a/apps/studio/src/modules/session/slice.ts
+++ b/apps/studio/src/modules/session/slice.ts
@@ -1,11 +1,10 @@
-import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { createSlice } from "@reduxjs/toolkit";
 import Cookies from "js-cookie";
 import { SessionState } from "./types";
 import { handleSuccessfulAuthentication } from "./utils";
 import { logOutExpiredSession, receiveRefreshToken } from "../../api/actions";
 
 const initialState: SessionState = {
-  isArtistPricePlanSelected: false,
   // if refresh token is present, user is logged in or can refresh session
   isLoggedIn: !!Cookies.get("refreshToken"),
   verificationPingStartedAt: undefined,
@@ -22,12 +21,6 @@ const sessionSlice = createSlice({
     removeVerificationTimer: (state) => {
       state.verificationPingStartedAt = undefined;
     },
-    setIsArtistPricePlanSelected: (
-      state,
-      { payload }: PayloadAction<boolean>
-    ) => {
-      state.isArtistPricePlanSelected = payload;
-    },
     setIsLoggedIn: (state, { payload }) => {
       state.isLoggedIn = payload;
     },
@@ -43,7 +36,6 @@ const sessionSlice = createSlice({
 });
 
 export const {
-  setIsArtistPricePlanSelected,
   setIsLoggedIn,
   receiveSuccessfullAuthentication,
   startVerificationTimer,

--- a/apps/studio/src/modules/session/types.ts
+++ b/apps/studio/src/modules/session/types.ts
@@ -1,5 +1,4 @@
 export interface SessionState {
-  isArtistPricePlanSelected: boolean;
   isLoggedIn: boolean;
   verificationPingStartedAt?: number;
 }
@@ -29,6 +28,7 @@ export interface Profile {
   readonly spotifyProfile?: string;
   readonly soundCloudProfile?: string;
   readonly appleMusicProfile?: string;
+  readonly dspPlanSubscribed?: boolean;
 }
 
 export interface GetUserRequest {

--- a/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -26,7 +26,7 @@ import {
   UploadImageField,
   UploadSongField,
 } from "@newm-web/elements";
-import { useAppDispatch, useAppSelector } from "../../../common";
+import { useAppDispatch } from "../../../common";
 import { scrollToError, useEffectAfterMount } from "@newm-web/utils";
 import { useWindowDimensions } from "@newm-web/utils";
 import { useExtractProperty } from "@newm-web/utils";
@@ -35,7 +35,6 @@ import { useFormikContext } from "formik";
 import {
   VerificationStatus,
   emptyProfile,
-  selectSession,
   useGetProfileQuery,
 } from "../../../modules/session";
 import {
@@ -61,7 +60,12 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
   const ownersRef = useRef<HTMLDivElement>(null);
   const descriptionRef = useRef<HTMLTextAreaElement>(null);
 
-  const { data: { verificationStatus } = emptyProfile } = useGetProfileQuery();
+  const {
+    data: {
+      verificationStatus,
+      dspPlanSubscribed: isArtistPricePlanSelected,
+    } = emptyProfile,
+  } = useGetProfileQuery();
   const { data: genres = [] } = useGetGenresQuery();
   const { data: moodOptions = [] } = useGetMoodsQuery();
   const { data: languages = [] } = useGetLanguagesQuery();
@@ -77,7 +81,7 @@ const BasicSongDetails: FunctionComponent<BasicDonDetailsProps> = ({
     useFormikContext<UploadSongRequest>();
 
   // DSP pricing plan mint song toggling
-  const { isArtistPricePlanSelected } = useAppSelector(selectSession);
+
   const [isPricingPlansOpen, setIsPricingPlansOpen] = useState(false);
   const handlePricingPlanClose = () => {
     setIsPricingPlansOpen(false);


### PR DESCRIPTION
Add:
- Save DSP pricing plan selection to endpoint when user selects "Artist" plan option
- Endpoint reference for `dspPlanSubscribed` in `Profile` session type

Remove:
- Temporary redux artist selection state