### PR TITLE
fix: Alt copy for songs uploaded but no collabs

### DIFF
--- a/apps/studio/src/pages/home/owners/NoOwnersYet.tsx
+++ b/apps/studio/src/pages/home/owners/NoOwnersYet.tsx
@@ -5,11 +5,11 @@ import { Owner } from "@newm-web/assets";
 import { useNavigate } from "react-router-dom";
 
 interface NoOwnersYetProps {
-  totalCountOfSongs: number;
+  hasSongsUploaded: boolean;
 }
 
 const NoOwnersYet: FunctionComponent<NoOwnersYetProps> = ({
-  totalCountOfSongs,
+  hasSongsUploaded,
 }) => {
   const navigate = useNavigate();
 
@@ -39,9 +39,9 @@ const NoOwnersYet: FunctionComponent<NoOwnersYetProps> = ({
         width="compact"
         onClick={ () => navigate("/home/upload-song") }
       >
-        { totalCountOfSongs === 0
-          ? "Upload your first song"
-          : "Invite other collaborators" }
+        { hasSongsUploaded
+          ? "Invite other collaborators"
+          : "Upload your first song" }
       </Button>
     </Box>
   );

--- a/apps/studio/src/pages/home/owners/NoOwnersYet.tsx
+++ b/apps/studio/src/pages/home/owners/NoOwnersYet.tsx
@@ -4,7 +4,13 @@ import { Button, Typography } from "@newm-web/elements";
 import { Owner } from "@newm-web/assets";
 import { useNavigate } from "react-router-dom";
 
-const NoOwnersYet: FunctionComponent = () => {
+interface NoOwnersYetProps {
+  totalCountOfSongs: number;
+}
+
+const NoOwnersYet: FunctionComponent<NoOwnersYetProps> = ({
+  totalCountOfSongs,
+}) => {
   const navigate = useNavigate();
 
   return (
@@ -33,7 +39,9 @@ const NoOwnersYet: FunctionComponent = () => {
         width="compact"
         onClick={ () => navigate("/home/upload-song") }
       >
-        Upload your first song
+        { totalCountOfSongs === 0
+          ? "Upload your first song"
+          : "Invite other collaborators" }
       </Button>
     </Box>
   );

--- a/apps/studio/src/pages/home/owners/OwnersTable.tsx
+++ b/apps/studio/src/pages/home/owners/OwnersTable.tsx
@@ -20,7 +20,10 @@ import {
 import AccountCircleIcon from "@mui/icons-material/AccountCircle";
 import NoOwnersYet from "./NoOwnersYet";
 import { history } from "../../../common/history";
-import { useGetCollaboratorsQuery } from "../../../modules/song";
+import {
+  useGetCollaboratorsQuery,
+  useGetSongCountQuery,
+} from "../../../modules/song";
 
 interface OwnersTableProps {
   query: string;
@@ -54,13 +57,20 @@ export default function OwnersTable({
 
   const {
     data: collaboratorsData = [],
-    isLoading,
+    isLoading: isLoadingCollaboratorsData,
     isSuccess,
   } = useGetCollaboratorsQuery({
     excludeMe: true,
     limit: collaboratorsToRequest,
     offset: (page - 1) * rowsPerPage,
     phrase: query,
+  });
+
+  const {
+    data: { count: totalCountOfSongs = 0 } = {},
+    isLoading: isLoadingTotalCountOfSongs,
+  } = useGetSongCountQuery({
+    ownerIds: ["me"],
   });
 
   const handlePageChange = (
@@ -99,7 +109,7 @@ export default function OwnersTable({
     }
   }, [viewportHeight]);
 
-  if (isLoading) {
+  if (isLoadingCollaboratorsData || isLoadingTotalCountOfSongs) {
     return (
       <TableSkeleton
         cols={
@@ -110,7 +120,7 @@ export default function OwnersTable({
   }
 
   if (isSuccess && collaboratorsData?.length === 0 && !query) {
-    return <NoOwnersYet />;
+    return <NoOwnersYet totalCountOfSongs={ totalCountOfSongs } />;
   }
 
   return collaboratorsData?.length ? (

--- a/apps/studio/src/pages/home/owners/OwnersTable.tsx
+++ b/apps/studio/src/pages/home/owners/OwnersTable.tsx
@@ -73,6 +73,8 @@ export default function OwnersTable({
     ownerIds: ["me"],
   });
 
+  const hasSongsUploaded = totalCountOfSongs > 0;
+
   const handlePageChange = (
     _event: React.ChangeEvent<unknown>,
     page: number
@@ -120,7 +122,7 @@ export default function OwnersTable({
   }
 
   if (isSuccess && collaboratorsData?.length === 0 && !query) {
-    return <NoOwnersYet totalCountOfSongs={ totalCountOfSongs } />;
+    return <NoOwnersYet hasSongsUploaded={ hasSongsUploaded } />;
   }
 
   return collaboratorsData?.length ? (


### PR DESCRIPTION
Fix:
- Show alternative copy for the Upload a Song navigation button within the no collabs component (`NoOwnersYet.tsx`), on the collaborator page, when songs are already uploaded to the Artists account but no collabs are attached to any of the songs

https://projectnewm.atlassian.net/browse/STUD-59