### PR TITLE
fix: Validate wallet and profile only in mint form

### DIFF
--- a/apps/studio/src/pages/home/library/MintSong.tsx
+++ b/apps/studio/src/pages/home/library/MintSong.tsx
@@ -281,6 +281,12 @@ const MintSong = () => {
             ? dirty
             : values.isMinting;
 
+          // if minting has been toggled but mint hasn't been initiated
+          const isMintingFormVisible = !isMintingInitiated && values.isMinting;
+
+          const isStepOneButtonDisabled =
+            isMintingFormVisible && (!isVerified || !wallet);
+
           const handleChangeOwners = (values: ReadonlyArray<Owner>) => {
             setFieldValue("owners", values);
           };
@@ -347,7 +353,7 @@ const MintSong = () => {
                       </Box>
                     ) }
 
-                    { !isMintingInitiated && values.isMinting && !isVerified && (
+                    { isMintingFormVisible && !isVerified && (
                       <Alert
                         action={
                           <Button
@@ -376,7 +382,7 @@ const MintSong = () => {
                       </Alert>
                     ) }
 
-                    { !isMintingInitiated && values.isMinting && !wallet && (
+                    { isMintingFormVisible && !wallet && (
                       <Alert
                         action={
                           <Button
@@ -424,9 +430,7 @@ const MintSong = () => {
 
                     { isStepOneButtonVisible && (
                       <Button
-                        disabled={
-                          !isMintingInitiated && (!isVerified || !wallet)
-                        }
+                        disabled={ isStepOneButtonDisabled }
                         isLoading={ isLoading }
                         width={
                           windowWidth &&

--- a/apps/studio/src/pages/home/library/MintSong.tsx
+++ b/apps/studio/src/pages/home/library/MintSong.tsx
@@ -347,7 +347,7 @@ const MintSong = () => {
                       </Box>
                     ) }
 
-                    { values.isMinting && !isVerified && (
+                    { !isMintingInitiated && values.isMinting && !isVerified && (
                       <Alert
                         action={
                           <Button
@@ -376,7 +376,7 @@ const MintSong = () => {
                       </Alert>
                     ) }
 
-                    { values.isMinting && !wallet && (
+                    { !isMintingInitiated && values.isMinting && !wallet && (
                       <Alert
                         action={
                           <Button
@@ -424,7 +424,9 @@ const MintSong = () => {
 
                     { isStepOneButtonVisible && (
                       <Button
-                        disabled={ !isVerified || !wallet }
+                        disabled={
+                          !isMintingInitiated && (!isVerified || !wallet)
+                        }
                         isLoading={ isLoading }
                         width={
                           windowWidth &&


### PR DESCRIPTION
fix:
- Update conditionals to only show wallet and profile verification alerts to user while they're completing the Distribute & Minting form.
- Update next step button conditional to only be disabled when a wallet isn't connected or profile verfication hasn't been completed when the user is completing the Distribute & Mint form 

Note: Currently the business logic doesn't make the Distribute & Mint form visible within the `MINTING` tab. This is done via the `edit` page not the `view-details` page. I chose to keep the logic as is since the JIRA request was to remove the alerts from being visible when Minting had already been initiated. A ticket will be created to address removing the Distribute & Mint form logic within `MintSong.tsx` or otherwise consolidating the `edit` and `view-details` pages into one page.

https://projectnewm.atlassian.net/browse/STUD-50