### PR TITLE
STUD-319: Stop error toasts from auto dismissing

### DIFF
--- a/packages/components/src/lib/Alert.tsx
+++ b/packages/components/src/lib/Alert.tsx
@@ -32,7 +32,7 @@ const Alert: FunctionComponent<AlertProps> = ({
   return isOpen ? (
     <Snackbar
       anchorOrigin={ { horizontal: "right", vertical: "top" } }
-      autoHideDuration={ 6000 }
+      autoHideDuration={ severity === "error" ? null : 6000 }
       open={ isOpen }
       sx={ {
         "&.MuiSnackbar-root": {


### PR DESCRIPTION
Update:
- Added conditional to `autoHideDuration` to prevent error alerts/toasts from auto dismissing

Note: Easiest way to test this is to attempt to connect a wallet that doesn't have it's DApp Account connected, wait 10 seconds for the error message to appear, error should be persistent