### PR TITLE
MRKT-147 Update currency symbol formatting within wallet dropdown (and across Studio and Marketplace)

### DIFF
--- a/apps/marketplace/src/components/modals/PurchaseStreamTokensModal.tsx
+++ b/apps/marketplace/src/components/modals/PurchaseStreamTokensModal.tsx
@@ -244,7 +244,7 @@ const PurchaseStreamTokensModal: FunctionComponent<
               </Stack>
             </Stack>
             <Typography variant="subtitle2">
-              { `Total does not include the network fee (≈ ${TRANSACTION_FEE_IN_ADA} ADA) for using the
+              { `Total does not include the network fee (≈₳${TRANSACTION_FEE_IN_ADA}) for using the
               Cardano blockchain. Fee prices are not guaranteed, costs may vary.
               Stream tokens may take several minutes to appear in the wallet.` }
             </Typography>

--- a/apps/studio/src/components/dspPricing/PricingPlansDialog.tsx
+++ b/apps/studio/src/components/dspPricing/PricingPlansDialog.tsx
@@ -39,21 +39,21 @@ const PricingPlansDialog = ({ onClose, open }: PricingPlansDialogProps) => {
     : "N/A";
 
   const dspFormattedPricingAda = dspPriceAda
-    ? `(≈${formatPriceToDecimal(dspPriceAda)}₳/RELEASE)`
+    ? `(≈₳${formatPriceToDecimal(dspPriceAda)}/RELEASE)`
     : undefined;
 
   const collabFormattedPricing = collabPerArtistPriceAda
-    ? ` (≈${formatPriceToDecimal(collabPerArtistPriceAda, 1)}₳/each)`
+    ? ` (≈₳${formatPriceToDecimal(collabPerArtistPriceAda, 1)}/each)`
     : "";
 
   const totalMintFormattedPricing =
     mintPriceAda && collabPerArtistPriceAda
-      ? ` (≈${formatPriceToDecimal(
+      ? ` (≈₳${formatPriceToDecimal(
           String(
             parseFloat(mintPriceAda) + parseFloat(collabPerArtistPriceAda)
           ),
           1
-        )}₳/release)`
+        )}/release)`
       : "";
 
   const pricingPlanCriteria = [

--- a/apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx
+++ b/apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx
@@ -103,7 +103,7 @@ export const CreateSale = () => {
       .typeError("")
       .when("saleCurrency", {
         is: (val: string) => val === Currency.USD.name,
-        otherwise: (s) => s.min(1, "Value must be at least 1 Ɲ"),
+        otherwise: (s) => s.min(1, "Value must be at least Ɲ1"),
         then: (s) => s.min(0.01, "Value must be at least $0.01"),
       }),
   });

--- a/apps/studio/src/pages/home/uploadSong/PriceSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/PriceSummaryDialog.tsx
@@ -72,7 +72,7 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             Total amount
           </Typography>
           <Typography variant="h3">
-            { formatPriceToDecimal(songEstimate?.adaPrice) || "N/A" }₳
+            ₳{ formatPriceToDecimal(songEstimate?.adaPrice) || "N/A" }
           </Typography>
           <Typography variant="subtitle1">
             ${ formatPriceToDecimal(songEstimate?.usdPrice) || "N/A" }
@@ -102,7 +102,7 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             </Stack>
             <Stack rowGap={ 0.5 }>
               <Typography>
-                { formatPriceToDecimal(songEstimate?.mintPriceAda) || "N/A" }₳
+                ₳{ formatPriceToDecimal(songEstimate?.mintPriceAda) || "N/A" }
               </Typography>
               <Typography variant="subtitle1">
                 ${ formatPriceToDecimal(songEstimate?.mintPriceUsd) || "N/A" }
@@ -131,7 +131,7 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             </Stack>
             <Stack rowGap={ 0.5 }>
               <Typography>
-                { formatPriceToDecimal(songEstimate?.collabPriceAda) || "N/A" }₳
+                ₳{ formatPriceToDecimal(songEstimate?.collabPriceAda) || "N/A" }
               </Typography>
               <Typography variant="subtitle1">
                 ${ formatPriceToDecimal(songEstimate?.collabPriceUsd) || "N/A" }
@@ -154,7 +154,7 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             </Stack>
             <Stack rowGap={ 0.5 }>
               <Typography>
-                { formatPriceToDecimal(songEstimate?.dspPriceAda) || "N/A" }₳
+                ₳{ formatPriceToDecimal(songEstimate?.dspPriceAda) || "N/A" }
               </Typography>
               <Typography variant="subtitle1">
                 ${ formatPriceToDecimal(songEstimate?.dspPriceUsd) || "N/A" }
@@ -182,7 +182,7 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
           </Stack>
           <Stack rowGap={ 0.5 }>
             <Typography>
-              { formatPriceToDecimal(songEstimate?.adaPrice) || "N/A" }₳
+              ₳{ formatPriceToDecimal(songEstimate?.adaPrice) || "N/A" }
             </Typography>
             <Typography variant="subtitle1">
               ${ formatPriceToDecimal(songEstimate?.usdPrice) || "N/A" }

--- a/packages/components/src/lib/earnings/EarningsSummaryModal.tsx
+++ b/packages/components/src/lib/earnings/EarningsSummaryModal.tsx
@@ -101,10 +101,7 @@ const EarningsSummaryModal: FunctionComponent<
                     }) }
                     )
                   </Typography>
-                  ₳
-                  { formatAdaAmount(transactionFeeInADA, {
-                    includeCurrencySymbol: false,
-                  }) }
+                  { formatAdaAmount(transactionFeeInADA) }
                 </Typography>
               </Stack>
             </Stack>

--- a/packages/components/src/lib/earnings/EarningsSummaryModal.tsx
+++ b/packages/components/src/lib/earnings/EarningsSummaryModal.tsx
@@ -76,12 +76,12 @@ const EarningsSummaryModal: FunctionComponent<
               >
                 <Typography variant="subtitle1">Earnings</Typography>
                 <Typography variant="h4">
-                  <Typography component="span" mr={ 0.5 } variant="subtitle2">
+                  <Typography component="span" mr={ 1 } variant="subtitle2">
                     (
                     { formatUsdAmount(unclaimedEarningsInUSD, {
                       includeEstimateSymbol: true,
                     }) }
-                    ){ " " }
+                    )
                   </Typography>
                   { formatNewmAmount(unclaimedEarningsInNEWM) }
                 </Typography>
@@ -94,17 +94,17 @@ const EarningsSummaryModal: FunctionComponent<
               >
                 <Typography variant="subtitle1">Transaction fee</Typography>
                 <Typography variant="h4">
-                  <Typography component="span" mr={ 0.5 } variant="subtitle2">
+                  <Typography component="span" mr={ 1 } variant="subtitle2">
                     (
                     { formatUsdAmount(transactionFeeInUSD, {
                       includeEstimateSymbol: true,
                     }) }
-                    ){ " " }
+                    )
                   </Typography>
+                  ₳
                   { formatAdaAmount(transactionFeeInADA, {
                     includeCurrencySymbol: false,
-                  }) }{ " " }
-                  ₳
+                  }) }
                 </Typography>
               </Stack>
             </Stack>

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -26,7 +26,7 @@ export const formatNewmAmount = (
     precision: 3,
   }
 ) => {
-  if (!amount) return "0 Ɲ";
+  if (!amount) return "Ɲ0";
 
   const {
     includeCurrencySymbol = true,
@@ -39,7 +39,7 @@ export const formatNewmAmount = (
   }
 
   const formattedAmount = currency(amount, {
-    pattern: "# !",
+    pattern: "!#",
     precision,
     symbol: includeCurrencySymbol ? "Ɲ" : "",
   }).format();
@@ -59,7 +59,7 @@ export const formatAdaAmount = (
     precision: 2,
   }
 ) => {
-  if (!amount) return "₳ 0";
+  if (!amount) return "₳0";
 
   const {
     includeCurrencySymbol = true,
@@ -68,12 +68,12 @@ export const formatAdaAmount = (
   } = options;
 
   const formattedAmount = currency(amount, {
-    pattern: "! #",
+    pattern: "!#",
     precision,
     symbol: includeCurrencySymbol ? "₳" : "",
   }).format();
 
-  return includeEstimateSymbol ? `≈ ${formattedAmount}` : formattedAmount;
+  return includeEstimateSymbol ? `≈${formattedAmount}` : formattedAmount;
 };
 
 /**
@@ -106,7 +106,7 @@ export const formatUsdAmount = (
     symbol: includeCurrencySymbol ? "$" : "",
   }).format();
 
-  return includeEstimateSymbol ? `≈ ${formattedAmount}` : formattedAmount;
+  return includeEstimateSymbol ? `≈${formattedAmount}` : formattedAmount;
 };
 
 export const Currency = {


### PR DESCRIPTION
Update:
- Currency symbol pattern in the following locations:
  - Sale Item > Purchase Stream Tokens Modal (Marketplace)
  - Upload Song > Pricing Plan Dialog (Studio)
  - Marketplace Tab > Create Sale (Studio)
  - Upload Song > Price Summary Dialog (Studio)
  - Wallet > Earnings Summary Modal (Studio)
  - Wallet Dropdown (Studio & Marketplace)
  - Misc, all other places that used the crypto currency formatters for ₳ and Ɲ