### PR TITLE
STUD-471: Fix error state of songs when edit flow payment tx errors occur

### DIFF
--- a/apps/studio/src/common/song.ts
+++ b/apps/studio/src/common/song.ts
@@ -3,6 +3,9 @@ import { MintingStatus } from "@newm-web/types";
 export const isSongEditable = (mintingStatus: MintingStatus) => {
   return (
     mintingStatus === MintingStatus.Undistributed ||
-    mintingStatus === MintingStatus.Declined
+    mintingStatus === MintingStatus.Declined ||
+    // Keeps user on edit flow even after payments fail after a tx error
+    mintingStatus === MintingStatus.MintingPaymentRequested ||
+    mintingStatus === MintingStatus.StreamTokenAgreementApproved
   );
 };


### PR DESCRIPTION
Add additional minting statuses to allow users to edit songs
even after payment issues, improving user experience during
the minting process.