### PR TITLE
fix: Update error message for insufficient ADA

### DIFF
--- a/apps/marketplace/src/modules/wallet/thunks.ts
+++ b/apps/marketplace/src/modules/wallet/thunks.ts
@@ -28,7 +28,7 @@ export const claimEarnings = createAsyncThunk(
 
       if (!utxoCborHexList) {
         throw new Error(
-          "Insufficient NEWM in wallet. Please add NEWM to your wallet and try again."
+          "Insufficient ADA in wallet. Please add ADA to your wallet and try again."
         );
       }
 

--- a/apps/studio/src/modules/wallet/thunks.ts
+++ b/apps/studio/src/modules/wallet/thunks.ts
@@ -28,7 +28,7 @@ export const claimEarnings = createAsyncThunk(
 
       if (!utxoCborHexList) {
         throw new Error(
-          "Insufficient NEWM in wallet. Please add NEWM to your wallet and try again."
+          "Insufficient ADA in wallet. Please add ADA to your wallet and try again."
         );
       }
 


### PR DESCRIPTION
This change updates the error message thrown when there are insufficient funds in the wallet from NEWM to ADA during earning claims, providing clearer guidance to users on the required currency for transactions.

Linking [STUD-482](https://projectnewm.atlassian.net/browse/STUD-482) and [MRKT-228](https://projectnewm.atlassian.net/browse/MRKT-228)

[STUD-482]: https://projectnewm.atlassian.net/browse/STUD-482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[MRKT-228]: https://projectnewm.atlassian.net/browse/MRKT-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ