### PR TITLE
chore: Bump version for marketplace and studio

### DIFF
--- a/apps/marketplace/package.json
+++ b/apps/marketplace/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@newm-web/marketplace",
-  "version": "1.0.12"
+  "version": "1.0.13"
 }

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -1,4 +1,4 @@
 {
   "name": "@newm-web/studio",
-  "version": "1.4.15"
+  "version": "1.4.16"
 }


### PR DESCRIPTION
This commit updates the version numbers for the marketplace and studio
packages to reflect the latest releases. The marketplace version is
updated to 1.0.13 and the studio version to 1.4.16.