### PR TITLE
STUD-477-Update-ADA-payment-process-in-Studio-using-new-mintPaymentOptions-endpoint-schema

### DIFF
--- a/apps/studio/src/modules/song/types.ts
+++ b/apps/studio/src/modules/song/types.ts
@@ -131,7 +131,7 @@ export interface UploadSongThunkRequest
   readonly isInstrumental?: boolean;
   readonly isMinting: boolean;
   readonly owners: Array<Owner>;
-  readonly paymentType?: PaymentType;
+  readonly paymentType: PaymentType;
   readonly stageName: string;
 }
 
@@ -367,7 +367,7 @@ export interface getMintSongPaymentResponse {
 }
 
 export interface getMintSongPaymentRequest {
-  paymentType?: PaymentType;
+  paymentType: PaymentType;
   songId: string;
 }
 

--- a/apps/studio/src/modules/song/types.ts
+++ b/apps/studio/src/modules/song/types.ts
@@ -361,8 +361,6 @@ export interface SubmitTransactionRequest {
 }
 
 export interface getMintSongPaymentResponse {
-  /** @deprecated Use mintPaymentOptions instead */
-  readonly cborHex: string;
   readonly mintPaymentOptions: ReadonlyArray<MintPaymentOptions>;
 }
 

--- a/apps/studio/src/pages/home/library/EditSong.tsx
+++ b/apps/studio/src/pages/home/library/EditSong.tsx
@@ -26,6 +26,7 @@ import { emptyProfile, useGetProfileQuery } from "../../../modules/session";
 import {
   CollaborationStatus,
   PatchSongThunkRequest,
+  PaymentType,
   emptySong,
   getIsSongDeletable,
   useDeleteSongThunk,
@@ -195,7 +196,7 @@ const EditSong: FunctionComponent = () => {
               status: CollaborationStatus.Editing,
             },
           ],
-    paymentType: undefined,
+    paymentType: PaymentType.ADA,
     phonographicCopyrightOwner,
     phonographicCopyrightYear,
     publicationDate,

--- a/apps/studio/src/pages/home/uploadSong/PriceSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/PriceSummaryDialog.tsx
@@ -78,8 +78,7 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             Total amount
           </Typography>
           <Typography variant="h3">
-            { /* TODO: Replace formatPriceToDecimal to formatADAAmount */ }₳
-            { formatPriceToDecimal(displayPrices?.price) || "N/A" }
+            ₳{ formatPriceToDecimal(displayPrices?.price) || "N/A" }
           </Typography>
           <Typography variant="subtitle1">
             ${ formatPriceToDecimal(displayPrices?.priceUsd) || "N/A" }

--- a/apps/studio/src/pages/home/uploadSong/PriceSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/PriceSummaryDialog.tsx
@@ -12,6 +12,7 @@ import { Button, Dialog, HorizontalLine } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 import { formatPriceToDecimal } from "@newm-web/utils";
 import {
+  PaymentType,
   UploadSongThunkRequest,
   getCollaboratorInfo,
   useGetCollaboratorsQuery,
@@ -28,9 +29,14 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
   onClose,
 }) => {
   const { values, submitForm } = useFormikContext<UploadSongThunkRequest>();
+
   const { data: songEstimate } = useGetMintSongEstimateQuery({
     collaborators: values.owners.length,
   });
+
+  const displayPrices = songEstimate?.mintPaymentOptions?.find(
+    (option) => option.paymentType === PaymentType.ADA
+  );
 
   const ownerEmails = values.owners.map((owner) => owner.email);
 
@@ -72,10 +78,11 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             Total amount
           </Typography>
           <Typography variant="h3">
-            ₳{ formatPriceToDecimal(songEstimate?.adaPrice) || "N/A" }
+            { /* TODO: Replace formatPriceToDecimal to formatADAAmount */ }₳
+            { formatPriceToDecimal(displayPrices?.price) || "N/A" }
           </Typography>
           <Typography variant="subtitle1">
-            ${ formatPriceToDecimal(songEstimate?.usdPrice) || "N/A" }
+            ${ formatPriceToDecimal(displayPrices?.priceUsd) || "N/A" }
           </Typography>
         </Stack>
 
@@ -102,10 +109,10 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             </Stack>
             <Stack rowGap={ 0.5 }>
               <Typography>
-                ₳{ formatPriceToDecimal(songEstimate?.mintPriceAda) || "N/A" }
+                ₳{ formatPriceToDecimal(displayPrices?.mintPrice) || "N/A" }
               </Typography>
               <Typography variant="subtitle1">
-                ${ formatPriceToDecimal(songEstimate?.mintPriceUsd) || "N/A" }
+                ${ formatPriceToDecimal(displayPrices?.mintPriceUsd) || "N/A" }
               </Typography>
             </Stack>
           </Stack>
@@ -131,10 +138,10 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             </Stack>
             <Stack rowGap={ 0.5 }>
               <Typography>
-                ₳{ formatPriceToDecimal(songEstimate?.collabPriceAda) || "N/A" }
+                ₳{ formatPriceToDecimal(displayPrices?.collabPrice) || "N/A" }
               </Typography>
               <Typography variant="subtitle1">
-                ${ formatPriceToDecimal(songEstimate?.collabPriceUsd) || "N/A" }
+                ${ formatPriceToDecimal(displayPrices?.collabPriceUsd) || "N/A" }
               </Typography>
             </Stack>
           </Stack>
@@ -154,10 +161,10 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
             </Stack>
             <Stack rowGap={ 0.5 }>
               <Typography>
-                ₳{ formatPriceToDecimal(songEstimate?.dspPriceAda) || "N/A" }
+                ₳{ formatPriceToDecimal(displayPrices?.dspPrice) || "N/A" }
               </Typography>
               <Typography variant="subtitle1">
-                ${ formatPriceToDecimal(songEstimate?.dspPriceUsd) || "N/A" }
+                ${ formatPriceToDecimal(displayPrices?.dspPriceUsd) || "N/A" }
               </Typography>
             </Stack>
           </Stack>
@@ -182,10 +189,10 @@ const PriceSummaryDialog: FunctionComponent<PriceSummaryDialogProps> = ({
           </Stack>
           <Stack rowGap={ 0.5 }>
             <Typography>
-              ₳{ formatPriceToDecimal(songEstimate?.adaPrice) || "N/A" }
+              ₳{ formatPriceToDecimal(displayPrices?.price) || "N/A" }
             </Typography>
             <Typography variant="subtitle1">
-              ${ formatPriceToDecimal(songEstimate?.usdPrice) || "N/A" }
+              ${ formatPriceToDecimal(displayPrices?.priceUsd) || "N/A" }
             </Typography>
           </Stack>
         </Stack>

--- a/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
@@ -34,7 +34,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
     useFormikContext<UploadSongThunkRequest>();
 
   useEffect(() => {
-    if (!values.paymentType) {
+    if (values.paymentType === PaymentType.ADA) {
       setFieldValue("paymentType", PaymentType.NEWM);
     }
   }, [setFieldValue, values.paymentType]);

--- a/apps/studio/src/pages/home/uploadSong/UploadSong.tsx
+++ b/apps/studio/src/pages/home/uploadSong/UploadSong.tsx
@@ -18,6 +18,7 @@ import {
 import { emptyProfile, useGetProfileQuery } from "../../../modules/session";
 import {
   CollaborationStatus,
+  PaymentType,
   UploadSongThunkRequest,
   useGenerateArtistAgreementThunk,
   useGetEarliestReleaseDateQuery,
@@ -98,7 +99,7 @@ const UploadSong: FunctionComponent = () => {
         status: CollaborationStatus.Editing,
       },
     ],
-    paymentType: undefined,
+    paymentType: PaymentType.ADA,
     phonographicCopyrightOwner: undefined,
     phonographicCopyrightYear: undefined,
     publicationDate: undefined,


### PR DESCRIPTION
This Refactor moves away from the deprecating cborHex and ADA/USD pricing endpoint scheme and moves to the new `mintPaymentOptions` scheme to handle different payment methods. Set the default payment type to ADA in the EditSong and UploadSong components. Require paymentType in the song payment flow to enhance type safety and reduce extraneous code.