### PR TITLE
MRKT-113-404-Page-Not-Found-error-page-for-Pages-Sales-and-Artist-in-Marketplace

### DIFF
--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -2,9 +2,9 @@
 import { Container, Stack, Typography } from "@mui/material";
 import { FunctionComponent, useState } from "react";
 import { ProfileHeader, ProfileModal } from "@newm-web/components";
+import { notFound } from "next/navigation";
 import { useGetArtistQuery } from "../../../modules/artist";
 import { ArtistSongs, BannerImage, SimilarArtists } from "../../../components";
-import NotFound from "../../not-found";
 
 interface ArtistProps {
   readonly params: {
@@ -27,7 +27,7 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
 
   // If the artist is not found, redirect to the 404 page, an error toast will display
   if (!isLoading && !artist) {
-    return <NotFound />;
+    notFound();
   }
 
   return (

--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -4,6 +4,7 @@ import { FunctionComponent, useState } from "react";
 import { ProfileHeader, ProfileModal } from "@newm-web/components";
 import { useGetArtistQuery } from "../../../modules/artist";
 import { ArtistSongs, BannerImage, SimilarArtists } from "../../../components";
+import NotFound from "../../not-found";
 
 interface ArtistProps {
   readonly params: {
@@ -23,6 +24,11 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
     websiteUrl: artist?.websiteUrl || "",
     xUrl: artist?.twitterUrl || "",
   };
+
+  // If the artist is not found, redirect to the 404 page, an error toast will display
+  if (!isLoading && !artist) {
+    return <NotFound />;
+  }
 
   return (
     <>

--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -13,7 +13,7 @@ interface ArtistProps {
 }
 
 const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
-  const { isLoading, data: artist } = useGetArtistQuery(params.artistId);
+  const { isLoading, data: artist, error } = useGetArtistQuery(params.artistId);
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
 
   const socials = {
@@ -26,7 +26,7 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
   };
 
   // If the artist is not found, redirect to the 404 page, an error toast will display
-  if (!isLoading && !artist) {
+  if (!isLoading && (!artist || error)) {
     notFound();
   }
 

--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -25,7 +25,7 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
     xUrl: artist?.twitterUrl || "",
   };
 
-  // If the artist is not found, redirect to the 404 page, an error toast will display
+  // If the artist is not found, redirect to the 404 page
   if (!isLoading && (!artist || error)) {
     notFound();
   }

--- a/apps/marketplace/src/app/sale/[saleId]/page.tsx
+++ b/apps/marketplace/src/app/sale/[saleId]/page.tsx
@@ -2,10 +2,10 @@
 import { Container } from "@mui/material";
 import { FunctionComponent } from "react";
 import { HorizontalLine } from "@newm-web/elements";
+import { notFound } from "next/navigation";
 import { useGetSaleQuery } from "../../../modules/sale";
 import MoreSongs from "../../../components/MoreSongs";
 import { Sale, SaleMetadata, SimilarSongs } from "../../../components";
-import NotFound from "../../not-found";
 
 interface SingleSongProps {
   readonly params: {
@@ -18,7 +18,7 @@ const SingleSong: FunctionComponent<SingleSongProps> = ({ params }) => {
 
   // If the sale is not found, redirect to the 404 page, an error toast will display
   if (!isLoading && !sale) {
-    return <NotFound />;
+    notFound();
   }
 
   return (

--- a/apps/marketplace/src/app/sale/[saleId]/page.tsx
+++ b/apps/marketplace/src/app/sale/[saleId]/page.tsx
@@ -14,10 +14,10 @@ interface SingleSongProps {
 }
 
 const SingleSong: FunctionComponent<SingleSongProps> = ({ params }) => {
-  const { isLoading, data: sale } = useGetSaleQuery(params.saleId);
+  const { isLoading, data: sale, error } = useGetSaleQuery(params.saleId);
 
   // If the sale is not found, redirect to the 404 page, an error toast will display
-  if (!isLoading && !sale) {
+  if (!isLoading && (!sale || error)) {
     notFound();
   }
 

--- a/apps/marketplace/src/app/sale/[saleId]/page.tsx
+++ b/apps/marketplace/src/app/sale/[saleId]/page.tsx
@@ -16,7 +16,7 @@ interface SingleSongProps {
 const SingleSong: FunctionComponent<SingleSongProps> = ({ params }) => {
   const { isLoading, data: sale, error } = useGetSaleQuery(params.saleId);
 
-  // If the sale is not found, redirect to the 404 page, an error toast will display
+  // If the sale is not found, redirect to the 404 page
   if (!isLoading && (!sale || error)) {
     notFound();
   }

--- a/apps/marketplace/src/app/sale/[saleId]/page.tsx
+++ b/apps/marketplace/src/app/sale/[saleId]/page.tsx
@@ -2,10 +2,10 @@
 import { Container } from "@mui/material";
 import { FunctionComponent } from "react";
 import { HorizontalLine } from "@newm-web/elements";
-import { useRouter } from "next/navigation";
 import { useGetSaleQuery } from "../../../modules/sale";
 import MoreSongs from "../../../components/MoreSongs";
 import { Sale, SaleMetadata, SimilarSongs } from "../../../components";
+import NotFound from "../../not-found";
 
 interface SingleSongProps {
   readonly params: {
@@ -14,15 +14,11 @@ interface SingleSongProps {
 }
 
 const SingleSong: FunctionComponent<SingleSongProps> = ({ params }) => {
-  const router = useRouter();
   const { isLoading, data: sale } = useGetSaleQuery(params.saleId);
 
-  // If the sale is not found, redirect to the home page, an error toast will display
-  // TODO: render 404 or error page
+  // If the sale is not found, redirect to the 404 page, an error toast will display
   if (!isLoading && !sale) {
-    router.push("/");
-
-    return null;
+    return <NotFound />;
   }
 
   return (

--- a/apps/marketplace/src/modules/artist/api.ts
+++ b/apps/marketplace/src/modules/artist/api.ts
@@ -12,19 +12,6 @@ import { Tags } from "../../api/newm/types";
 export const extendedApi = newmApi.injectEndpoints({
   endpoints: (build) => ({
     getArtist: build.query<GetArtistResponse, string>({
-      async onQueryStarted(body, { dispatch, queryFulfilled }) {
-        try {
-          await queryFulfilled;
-        } catch (error) {
-          dispatch(
-            setToastMessage({
-              message: "An error occurred while fetching artist",
-              severity: "error",
-            })
-          );
-        }
-      },
-
       providesTags: [Tags.Artist],
 
       query: (id) => ({

--- a/apps/marketplace/src/modules/sale/api.ts
+++ b/apps/marketplace/src/modules/sale/api.ts
@@ -84,19 +84,6 @@ export const extendedApi = newmApi.injectEndpoints({
       query: () => ({ method: "GET", url: "v1/marketplace/orders/fees" }),
     }),
     getSale: build.query<GetSaleResponse, string>({
-      async onQueryStarted(body, { dispatch, queryFulfilled }) {
-        try {
-          await queryFulfilled;
-        } catch (error) {
-          dispatch(
-            setToastMessage({
-              message: "An error occurred while fetching sale details",
-              severity: "error",
-            })
-          );
-        }
-      },
-
       providesTags: [Tags.Sale],
 
       query: (saleId) => ({

--- a/packages/components/src/lib/PageNotFound.tsx
+++ b/packages/components/src/lib/PageNotFound.tsx
@@ -34,18 +34,19 @@ const PageNotFound: FunctionComponent<PageNotFoundProps> = ({
         backgroundColor: theme.colors.black,
         gap: [2, 3],
         justifyContent: ["center", "start"],
-        mb: [0, 5],
+        mb: [0, 0],
         minHeight: "100vh",
+        pb: [4, 5],
+        pt: [4, 7.5],
         px: 0.5,
-        py: [4, 7.5],
         textAlign: "center" as const,
       } as SxProps,
       imageSpacing: {
-        mt: { md: 18, xs: 0 },
+        mt: { md: 15, xs: 0 },
       },
       newmLogo: { display: "block" },
       typographySpacing: {
-        mt: [3, 8.5],
+        mt: [3, 7],
       },
     },
     topbar: {
@@ -82,7 +83,7 @@ const PageNotFound: FunctionComponent<PageNotFoundProps> = ({
           color="white"
           component="h3"
           fontSize={ { sm: "32px", xs: "24px" } }
-          lineHeight={ { sm: "40px", xs: "24px" } }
+          lineHeight={ { sm: "38px", xs: "24px" } }
           mt={ currentStyles.typographySpacing.mt }
           variant="h3"
         >


### PR DESCRIPTION
Introduce a NotFound component to improve user experience by redirecting users to a 404 page when an artist or sale is not found. Adjust visual and responsive consistency of the PageNotFound component. Refine error handling in queries to no longer show error toast messages for artist and song sale query leading to 404 page.

[MRKT-113 Artist Page Not Found.webm](https://github.com/user-attachments/assets/f6cbad2e-9a82-4560-a6c8-601e340e5030)

[MRKT-113 Song Sale Page Not Found.webm](https://github.com/user-attachments/assets/897a9ae5-af21-4c5c-8705-bae078ee7a9e)
