### PR TITLE
STUD-478-No-payment-error-message-for-insufficient-funds-within-wallet-in-Edit-Song-flow

### DIFF
--- a/apps/studio/src/modules/song/thunks.ts
+++ b/apps/studio/src/modules/song/thunks.ts
@@ -506,6 +506,11 @@ export const patchSong = createAsyncThunk(
         history.push("/home/library");
       }
     } catch (error) {
+      // if error is a SilentError, do nothing so it doesn't clear toast
+      if (error instanceof SilentError) {
+        return;
+      }
+
       // non-endpoint related error occur, show toast
       if (error instanceof Error) {
         dispatch(


### PR DESCRIPTION
This change will ensure that if a SilentError occurs during the patchSong process, it will not clear the toast notification. Other errors will still trigger the appropriate toast message.

[STUD-478 Payment Error in Edit Song Flow.webm](https://github.com/user-attachments/assets/caafb43e-47ae-4272-832e-81bd006467a8)