### PR TITLE
STUD-486: Integrate PayPal payment through the Release Summary Modal

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -47,6 +47,12 @@ import store, { persistor } from "./store";
 import "./App.css";
 import LDUserUpdater from "./components/LDUserUpdater";
 import PingSaleComplete from "./components/sales/PingSaleComplete";
+import {
+  PayPalCancelledSession,
+  PayPalLoadingSession,
+  PayPalModal,
+  PayPalSuccessSession,
+} from "./components/paypal";
 
 const App = () => {
   const googleClientID = GOOGLE_CLIENT_ID;
@@ -68,6 +74,7 @@ const App = () => {
                 <CssBaseline />
                 <IdenfyPingUserStatus />
                 <IdenfyModal />
+                <PayPalModal />
                 <ConnectWalletModal />
                 <ReferralDashboard
                   campaignUUID={ REFERRALHERO_ARTIST_REFERRAL_CAMPAIGN_UUID }
@@ -112,6 +119,21 @@ const App = () => {
                       <Route
                         element={ <IdenfyFailSession /> }
                         path="idenfy-fail-session"
+                      />
+
+                      <Route
+                        element={ <PayPalSuccessSession /> }
+                        path="paypal-success-session"
+                      />
+
+                      <Route
+                        element={ <PayPalCancelledSession /> }
+                        path="paypal-cancelled-session"
+                      />
+
+                      <Route
+                        element={ <PayPalLoadingSession /> }
+                        path="paypal-loading-session"
                       />
 
                       <Route

--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -36,6 +36,9 @@ export const NONE_OPTION = "-";
 export const SKIP_FETCH_INVITE_PATH_LIST = [
   "/idenfy-success-session",
   "/idenfy-fail-session",
+  "/paypal-loading-session",
+  "/paypal-cancelled-session",
+  "/paypal-success-session",
 ];
 
 export const NEWM_MARKETPLACE_URL = isProd

--- a/apps/studio/src/common/index.ts
+++ b/apps/studio/src/common/index.ts
@@ -8,3 +8,4 @@ export * from "./regex";
 export * from "./song";
 export * from "./testUtils";
 export * from "./types";
+export * from "./paypalUtils";

--- a/apps/studio/src/common/paypalUtils.ts
+++ b/apps/studio/src/common/paypalUtils.ts
@@ -1,0 +1,64 @@
+let paypalPopup: Window | null = null;
+
+const calculatePopUpLocation = (width: number, height: number) => {
+  const openerX = (window.screenX ?? (window as any).screenLeft ?? 0) as number;
+  const openerY = (window.screenY ?? (window as any).screenTop ?? 0) as number;
+  const left = Math.max(
+    0,
+    Math.floor(openerX + (window.outerWidth - width) / 2)
+  );
+  const top = Math.max(
+    0,
+    Math.floor(openerY + (window.outerHeight - height) / 2)
+  );
+  return { left, top };
+};
+
+export const openPayPalPopup = (): Window | null => {
+  // No "noopener"/"noreferrer" so window.opener works for postMessage
+  const features = `width=300,height=300,left=${window.screenX},top=${window.screenY},menubar=no,toolbar=no,location=no,status=no,resizable=yes,scrollbars=yes`;
+
+  paypalPopup =
+    window.open(
+      `${window.location.origin}/paypal-loading-session`,
+      "PayPalPayment",
+      features
+    ) ?? null;
+
+  return paypalPopup;
+};
+
+export const navigatePayPalPopup = async (url: string): Promise<boolean> => {
+  if (!paypalPopup || paypalPopup.closed) return false;
+
+  try {
+    paypalPopup.location.replace(url);
+  } catch {
+    // Intentionally ignore: touching popup.document or replacing location can throw
+    // due to cross-origin restrictions or if the popup is mid-navigation.
+  }
+
+  try {
+    paypalPopup.resizeTo(400, 650);
+    const { left, top } = calculatePopUpLocation(400, 650);
+    paypalPopup.moveTo(left, top);
+  } catch {
+    // Intentionally ignore: some browsers/OSes block programmatic move/resize.
+  }
+  return true;
+};
+
+export const getPayPalPopup = (): Window | null => {
+  return paypalPopup && !paypalPopup.closed ? paypalPopup : null;
+};
+
+export const closePayPalPopup = () => {
+  if (paypalPopup && !paypalPopup.closed) {
+    try {
+      paypalPopup.close();
+    } catch {
+      // Intentionally ignore: UA may block close() or window may be already closed.
+    }
+  }
+  paypalPopup = null;
+};

--- a/apps/studio/src/components/paypal/PayPalCancelledSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalCancelledSession.tsx
@@ -1,0 +1,39 @@
+import { Stack, Typography } from "@mui/material";
+import { FunctionComponent, useEffect } from "react";
+import { Button } from "@newm-web/elements";
+import theme from "@newm-web/theme";
+
+const PayPalCancelledSession: FunctionComponent = () => {
+  useEffect(() => {
+    window.opener?.postMessage("paypal-payment-cancelled");
+  }, []);
+
+  const handleClick = () => {
+    window.parent.postMessage("paypal-popup-close");
+  };
+
+  return (
+    <Stack
+      sx={ {
+        alignItems: "center",
+        backgroundColor: theme.colors.black,
+        flexGrow: 1,
+        justifyContent: "center",
+      } }
+    >
+      <Typography variant="h1">OOPS!</Typography>
+      <Typography
+        sx={ {
+          fontWeight: 400,
+          my: [2, 3, 4],
+          px: [2, 3],
+        } }
+      >
+        Sorry, we couldn&apos;t complete payment. Please attempt payment again.
+      </Typography>
+      <Button onClick={ handleClick }>Got it</Button>
+    </Stack>
+  );
+};
+
+export default PayPalCancelledSession;

--- a/apps/studio/src/components/paypal/PayPalCancelledSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalCancelledSession.tsx
@@ -2,14 +2,14 @@ import { Stack, Typography } from "@mui/material";
 import { FunctionComponent, useEffect } from "react";
 import { Button } from "@newm-web/elements";
 import theme from "@newm-web/theme";
+import { NEWMLogo } from "@newm-web/assets";
 
 const PayPalCancelledSession: FunctionComponent = () => {
-  useEffect(() => {
-    window.opener?.postMessage("paypal-payment-cancelled");
-  }, []);
-
   const handleClick = () => {
-    window.parent.postMessage("paypal-popup-close");
+    window.opener?.postMessage(
+      "paypal-popup-cancelled",
+      window.location.origin
+    );
   };
 
   return (
@@ -21,12 +21,21 @@ const PayPalCancelledSession: FunctionComponent = () => {
         justifyContent: "center",
       } }
     >
-      <Typography variant="h1">OOPS!</Typography>
+      <NEWMLogo />
+      <Typography
+        sx={ {
+          mt: [2, 3, 4],
+        } }
+        variant="h1"
+      >
+        OOPS!
+      </Typography>
       <Typography
         sx={ {
           fontWeight: 400,
           my: [2, 3, 4],
           px: [2, 3],
+          textAlign: "center",
         } }
       >
         Sorry, we couldn&apos;t complete payment. Please attempt payment again.

--- a/apps/studio/src/components/paypal/PayPalLoadingSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalLoadingSession.tsx
@@ -1,0 +1,30 @@
+import { Stack, Typography } from "@mui/material";
+import { FunctionComponent } from "react";
+import theme from "@newm-web/theme";
+
+const PayPalLoadingSession: FunctionComponent = () => {
+  return (
+    <Stack
+      sx={ {
+        alignItems: "center",
+        backgroundColor: theme.colors.black,
+        flexGrow: 1,
+        justifyContent: "center",
+      } }
+    >
+      <Typography variant="h1">ALMOST THERE!</Typography>
+      <Typography
+        sx={ {
+          fontWeight: 400,
+          my: [2, 3, 4],
+          px: [2, 3],
+        } }
+      >
+        Loading PayPal checkout, please wait for the song upload process to
+        complete.
+      </Typography>
+    </Stack>
+  );
+};
+
+export default PayPalLoadingSession;

--- a/apps/studio/src/components/paypal/PayPalLoadingSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalLoadingSession.tsx
@@ -1,6 +1,7 @@
 import { Stack, Typography } from "@mui/material";
 import { FunctionComponent } from "react";
 import theme from "@newm-web/theme";
+import ResponsiveNEWMLogo from "../ResponsiveNEWMLogo";
 
 const PayPalLoadingSession: FunctionComponent = () => {
   return (
@@ -12,16 +13,24 @@ const PayPalLoadingSession: FunctionComponent = () => {
         justifyContent: "center",
       } }
     >
-      <Typography variant="h1">ALMOST THERE!</Typography>
+      <ResponsiveNEWMLogo />
+      <Typography
+        sx={ {
+          mt: [2, 3, 4],
+        } }
+        variant="h1"
+      >
+        ALMOST THERE!
+      </Typography>
       <Typography
         sx={ {
           fontWeight: 400,
           my: [2, 3, 4],
           px: [2, 3],
+          textAlign: "center",
         } }
       >
-        Loading PayPal checkout, please wait for the song upload process to
-        complete.
+        Loading PayPal checkout, please wait for the upload process to complete.
       </Typography>
     </Stack>
   );

--- a/apps/studio/src/components/paypal/PayPalModal.tsx
+++ b/apps/studio/src/components/paypal/PayPalModal.tsx
@@ -1,0 +1,64 @@
+import { FunctionComponent, useEffect } from "react";
+import { Box, Link, Typography } from "@mui/material";
+import { Modal } from "@newm-web/elements";
+import {
+  closePayPalPopup,
+  getPayPalPopup,
+  useAppDispatch,
+  useAppSelector,
+} from "../../common";
+import { selectUi } from "../../modules/ui";
+import { setIsPayPalModalOpen } from "../../modules/ui";
+
+const PayPalModal: FunctionComponent = () => {
+  const dispatch = useAppDispatch();
+  const { isPayPalModalOpen: isOpen } = useAppSelector(selectUi);
+
+  const handleClose = () => {
+    if (isOpen) dispatch(setIsPayPalModalOpen(false));
+    closePayPalPopup();
+  };
+
+  const handleFocusPopup = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+
+    const paypalPopUp = getPayPalPopup();
+    if (paypalPopUp && !paypalPopUp.closed) {
+      try {
+        paypalPopUp.focus();
+      } catch {
+        // Intentionally ignore: focus can fail on some browsers or if window state changed.
+      }
+      return;
+    }
+  };
+
+  return (
+    <Modal
+      isOpen={ isOpen }
+      style={ { height: "100%", width: "100%" } }
+      title="PayPal Payment"
+      onClose={ handleClose }
+    >
+      <Box
+        sx={ {
+          alignItems: "center",
+          display: "flex",
+          flexDirection: "column",
+          gap: 1.5,
+          p: 2.5,
+          textAlign: "center",
+        } }
+      >
+        <Typography variant="body1">
+          Please complete your PayPal payment in the pop-up window.
+        </Typography>
+        <Link href="#" underline="hover" onClick={ handleFocusPopup }>
+          Return to PayPal window
+        </Link>
+      </Box>
+    </Modal>
+  );
+};
+
+export default PayPalModal;

--- a/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
@@ -8,10 +8,6 @@ const PayPalSuccessSession: FunctionComponent = () => {
     window.opener?.postMessage("paypal-payment-success");
   }, []);
 
-  const handleClick = () => {
-    window.parent.postMessage("paypal-popup-close");
-  };
-
   return (
     <Stack
       sx={ {
@@ -23,10 +19,10 @@ const PayPalSuccessSession: FunctionComponent = () => {
     >
       <Typography variant="h1">THANK YOU!</Typography>
       <GradientTypography
-        style={ { ...theme.typography.emphasized } }
+        style={ { ...theme.typography.emphasized, textAlign: "center" } }
         variant="h1"
       >
-        Head back to the upload process.
+        Heading back to the upload process.
       </GradientTypography>
       <Typography
         sx={ {
@@ -36,7 +32,6 @@ const PayPalSuccessSession: FunctionComponent = () => {
       >
         Get ready to share your music and to claim royalties.
       </Typography>
-      <Button onClick={ handleClick }>Got it</Button>
     </Stack>
   );
 };

--- a/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
@@ -1,0 +1,44 @@
+import { FunctionComponent, useEffect } from "react";
+import { Stack, Typography } from "@mui/material";
+import { Button, GradientTypography } from "@newm-web/elements";
+import theme from "@newm-web/theme";
+
+const PayPalSuccessSession: FunctionComponent = () => {
+  useEffect(() => {
+    window.opener?.postMessage("paypal-payment-success");
+  }, []);
+
+  const handleClick = () => {
+    window.parent.postMessage("paypal-popup-close");
+  };
+
+  return (
+    <Stack
+      sx={ {
+        alignItems: "center",
+        backgroundColor: theme.colors.black,
+        flexGrow: 1,
+        justifyContent: "center",
+      } }
+    >
+      <Typography variant="h1">THANK YOU!</Typography>
+      <GradientTypography
+        style={ { ...theme.typography.emphasized } }
+        variant="h1"
+      >
+        Head back to the upload process.
+      </GradientTypography>
+      <Typography
+        sx={ {
+          fontWeight: 400,
+          my: [2, 3, 4],
+        } }
+      >
+        Get ready to share your music and to claim royalties.
+      </Typography>
+      <Button onClick={ handleClick }>Got it</Button>
+    </Stack>
+  );
+};
+
+export default PayPalSuccessSession;

--- a/apps/studio/src/components/paypal/index.ts
+++ b/apps/studio/src/components/paypal/index.ts
@@ -1,0 +1,4 @@
+export { default as PayPalModal } from "./PayPalModal";
+export { default as PayPalCancelledSession } from "./PayPalCancelledSession";
+export { default as PayPalSuccessSession } from "./PayPalSuccessSession";
+export { default as PayPalLoadingSession } from "./PayPalLoadingSession";

--- a/apps/studio/src/modules/song/api.ts
+++ b/apps/studio/src/modules/song/api.ts
@@ -141,7 +141,7 @@ export const extendedApi = newmApi.injectEndpoints({
         } catch (error) {
           dispatch(
             setToastMessage({
-              message: "An error occurred while creating PayPal order",
+              message: "An error occurred while creating the PayPal order",
               severity: "error",
             })
           );
@@ -671,7 +671,7 @@ export const extendedApi = newmApi.injectEndpoints({
         } catch (error) {
           dispatch(
             setToastMessage({
-              message: "An error occurred while submitting PayPal order",
+              message: "An error occurred while submitting the PayPal order",
               severity: "error",
             })
           );

--- a/apps/studio/src/modules/song/api.ts
+++ b/apps/studio/src/modules/song/api.ts
@@ -6,6 +6,8 @@ import {
   CreateCollaborationResponse,
   CreateMintSongPaymentRequest,
   CreateMintSongPaymentResponse,
+  CreatePayPalOrderPaymentRequest,
+  CreatePayPalOrderPaymentResponse,
   DeleteSongRequest,
   GetCollaborationsRequest,
   GetCollaborationsResponse,
@@ -28,6 +30,7 @@ import {
   PostSongRequest,
   ProcessStreamTokenAgreementRequest,
   ReplyCollaborationRequest,
+  SubmitPayPalOrderPaymentRequest,
   SubmitTransactionRequest,
   UpdateCollaborationRequest,
   UploadSongAudioRequest,
@@ -126,6 +129,29 @@ export const extendedApi = newmApi.injectEndpoints({
         body,
         method: "POST",
         url: `v1/songs/${songId}/mint/payment`,
+      }),
+    }),
+    createPayPalOrderPayment: build.mutation<
+      CreatePayPalOrderPaymentResponse,
+      CreatePayPalOrderPaymentRequest
+    >({
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          dispatch(
+            setToastMessage({
+              message: "An error occurred while creating PayPal order",
+              severity: "error",
+            })
+          );
+        }
+      },
+
+      query: (body) => ({
+        body,
+        method: "POST",
+        url: "v1/paypal/minting-distribution/orders",
       }),
     }),
     deleteCollaboration: build.mutation<void, string>({
@@ -612,6 +638,7 @@ export const extendedApi = newmApi.injectEndpoints({
         url: `v1/songs/${songId}/redistribute`,
       }),
     }),
+
     submitMintSongPayment: build.mutation<void, SubmitTransactionRequest>({
       invalidatesTags: [Tags.Song],
       async onQueryStarted(body, { dispatch, queryFulfilled }) {
@@ -631,6 +658,28 @@ export const extendedApi = newmApi.injectEndpoints({
         body,
         method: "POST",
         url: "v1/cardano/submitTransaction",
+      }),
+    }),
+    submitPayPalOrderPayment: build.mutation<
+      void,
+      SubmitPayPalOrderPaymentRequest
+    >({
+      invalidatesTags: [Tags.Song],
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          dispatch(
+            setToastMessage({
+              message: "An error occurred while submitting PayPal order",
+              severity: "error",
+            })
+          );
+        }
+      },
+      query: ({ orderId }) => ({
+        method: "POST",
+        url: `v1/paypal/minting-distribution/orders/${orderId}/capture`,
       }),
     }),
     updateCollaboration: build.mutation<void, UpdateCollaborationRequest>({

--- a/apps/studio/src/modules/song/thunks.ts
+++ b/apps/studio/src/modules/song/thunks.ts
@@ -14,6 +14,7 @@ import {
   DeleteSongRequest,
   GetUserWalletSongsRequest,
   PatchSongThunkRequest,
+  PaymentType,
   UpdateCollaborationsRequest,
   UploadSongThunkRequest,
 } from "./types";
@@ -27,6 +28,7 @@ import {
   getCollaborationsToUpdate,
   mapCollaboratorsToCollaborations,
   submitMintSongPayment,
+  submitPayPalPayment,
 } from "./utils";
 import { handleUploadProgress } from "../../modules/ui/utils";
 import { UploadSongError } from "../../common";
@@ -238,7 +240,11 @@ export const uploadSong = createAsyncThunk(
           })
         );
 
-        await submitMintSongPayment(songId, dispatch, body.paymentType);
+        if (body.paymentType === PaymentType.PAYPAL) {
+          await submitPayPalPayment(songId, dispatch);
+        } else {
+          await submitMintSongPayment(songId, dispatch, body.paymentType);
+        }
       }
 
       // display most recent status and allow progress animation to complete
@@ -487,7 +493,11 @@ export const patchSong = createAsyncThunk(
 
             if ("error" in reprocessSongResp) return;
           } else {
-            await submitMintSongPayment(body.id, dispatch, body.paymentType);
+            if (body.paymentType === PaymentType.PAYPAL) {
+              await submitPayPalPayment(body.id, dispatch);
+            } else {
+              await submitMintSongPayment(body.id, dispatch, body.paymentType);
+            }
           }
         }
       }

--- a/apps/studio/src/modules/song/types.ts
+++ b/apps/studio/src/modules/song/types.ts
@@ -466,3 +466,16 @@ export interface GetMintSongEstimateResponse {
   readonly usdPrice: string;
   readonly usdToPaymentTypeExchangeRate?: string;
 }
+
+export interface CreatePayPalOrderPaymentResponse {
+  readonly checkoutUrl: string;
+  readonly orderId: string;
+}
+
+export interface CreatePayPalOrderPaymentRequest {
+  readonly songId: string;
+}
+
+export interface SubmitPayPalOrderPaymentRequest {
+  readonly orderId: string;
+}

--- a/apps/studio/src/modules/ui/slice.ts
+++ b/apps/studio/src/modules/ui/slice.ts
@@ -5,6 +5,7 @@ const initialState: UIState = {
   isConnectWalletModalOpen: false,
   isIdenfyModalOpen: false,
   isInvitesModalOpen: false,
+  isPayPalModalOpen: false,
   isProgressBarModalOpen: false,
   isReferralDashboardModalOpen: false,
   isWalletEnvMismatchModalOpen: false,
@@ -54,6 +55,9 @@ const uiSlice = createSlice({
     setIsInvitesModalOpen: (state, { payload }: PayloadAction<boolean>) => {
       state.isInvitesModalOpen = payload;
     },
+    setIsPayPalModalOpen: (state, { payload }: PayloadAction<boolean>) => {
+      state.isPayPalModalOpen = payload;
+    },
     setIsProgressBarModalOpen: (state, { payload }: PayloadAction<boolean>) => {
       state.isProgressBarModalOpen = payload;
     },
@@ -93,6 +97,7 @@ export const {
   setIsConnectWalletModalOpen,
   setIsIdenfyModalOpen,
   setIsInvitesModalOpen,
+  setIsPayPalModalOpen,
   setIsProgressBarModalOpen,
   setIsReferralDashboardModalOpen,
   setIsWalletEnvMismatchModalOpen,

--- a/apps/studio/src/modules/ui/types.ts
+++ b/apps/studio/src/modules/ui/types.ts
@@ -4,6 +4,7 @@ export interface UIState {
   isConnectWalletModalOpen: boolean;
   isIdenfyModalOpen: boolean;
   isInvitesModalOpen: boolean;
+  isPayPalModalOpen: boolean;
   isProgressBarModalOpen: boolean;
   isReferralDashboardModalOpen: boolean;
   isWalletEnvMismatchModalOpen: boolean;

--- a/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/ReleaseSummaryDialog.tsx
@@ -20,6 +20,7 @@ import {
   UploadSongThunkRequest,
   useGetMintSongEstimateQuery,
 } from "../../../modules/song";
+import { openPayPalPopup } from "../../../common/paypalUtils";
 
 interface ReleaseSummaryDialogProps {
   readonly onClose: () => void;
@@ -59,6 +60,13 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     setFieldValue("paymentType", event.target.value);
+  };
+
+  const handleConfirmAndPay = () => {
+    if (values.paymentType === PaymentType.PAYPAL) {
+      openPayPalPopup(); // opens synchronously; avoids popup blocker
+    }
+    submitForm(); // your thunk will later navigate the popup to approval URL
   };
 
   return (
@@ -420,9 +428,9 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
             </Button>
             <Button
               disabled={ !displayPrices }
-              type="submit"
+              type="button"
               width="compact"
-              onClick={ submitForm }
+              onClick={ handleConfirmAndPay }
             >
               Confirm & Pay
             </Button>


### PR DESCRIPTION
Introduce PayPal endpoints and session components to integrate PayPal payment option for song minting. Update UI to manage PayPal modal and improve user flow during payment processing.

Notes: 
 - Backend is investigating an issue with post-capture of successful PayPal payment.
- The success and cancelled session pages will only navigate correctly on Garage and Studio.
- Payment enhancements, including PayPal flow, are behind an LD flag