### PR TITLE
STUD-480: Remove additional text from Referral Banner after first acknowledgement and referral

### DIFF
--- a/apps/studio/src/components/referralHero/ReferralBanner.tsx
+++ b/apps/studio/src/components/referralHero/ReferralBanner.tsx
@@ -4,7 +4,6 @@ import { Box, IconButton, Stack, Typography, useTheme } from "@mui/material";
 import { Button } from "@newm-web/elements";
 import { referralBannerBackground } from "@newm-web/assets";
 import { REFERRALHERO_ARTIST_REFERRAL_CAMPAIGN_UUID } from "@newm-web/env";
-import { Link } from "react-router-dom";
 import { getReferralHeroUserCampaignData, useAppDispatch } from "../../common";
 import { setIsReferralDashboardModalOpen } from "../../modules/ui";
 
@@ -44,55 +43,11 @@ const ReferralBanner: FunctionComponent<ReferralBannerProps> = ({
     return (
       <Box
         sx={ {
-          backgroundColor: theme.colors.grey700,
-          border: `2px solid ${theme.colors.grey500}`,
-          borderRadius: 2,
-          px: 1,
-          py: 1,
+          mt: -2,
+          px: 2,
+          py: 2,
         } }
       >
-        { !isReferralBannerDismissed && (
-          <IconButton
-            aria-label="close"
-            size="small"
-            sx={ {
-              color: theme.colors.white,
-              display: isCloseButtonVisible ? "block" : "none",
-              position: "absolute",
-              px: 0.5,
-              py: 0,
-              right: 0,
-              top: 0,
-            } }
-            onClick={ handleBannerDismiss }
-          >
-            <CloseIcon
-              sx={ {
-                fontSize: 12,
-              } }
-            />
-          </IconButton>
-        ) }
-        <Typography fontSize={ 12 } fontWeight={ 500 } mb={ 1 } textAlign="center">
-          You&apos;ve referred{ " " }
-          <Typography
-            component="span"
-            fontSize={ 14 }
-            fontWeight={ theme.typography.fontWeightBold }
-            variant="body2"
-          >
-            { usersSuccessfullyReferred }
-          </Typography>{ " " }
-          artists! Check your{ " " }
-          <Typography
-            component="span"
-            fontWeight={ theme.typography.fontWeightBold }
-            variant="inherit"
-          >
-            <Link to="/home/wallet">reward</Link>
-          </Typography>{ " " }
-          and invite more!
-        </Typography>
         <Button variant="primary" width="full" onClick={ handleBannerClick }>
           Invite an Artist
         </Button>

--- a/apps/studio/src/pages/home/SideBar.tsx
+++ b/apps/studio/src/pages/home/SideBar.tsx
@@ -160,7 +160,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
           </Typography>
         </Stack>
 
-        <Box mb={ 3 } mt={ 4 } width="100%">
+        <Box mb={ 2 } mt={ 3 } width="100%">
           <SideBarNavLink
             Icon={ UploadIcon }
             label="UPLOAD A SONG"
@@ -168,7 +168,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
             onClick={ () => setMobileOpen(false) }
           />
 
-          <Box ml={ 2.5 } mt={ 3.5 }>
+          <Box ml={ 2 } mt={ 3 }>
             <SideBarHeader>MY CAREER</SideBarHeader>
           </Box>
 
@@ -188,7 +188,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
             />
           </Stack>
 
-          <Box ml={ 2.5 } mt={ 3.5 }>
+          <Box ml={ 2.5 } mt={ 2.5 }>
             <SideBarHeader>MY PERFORMANCE</SideBarHeader>
           </Box>
 
@@ -201,7 +201,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
             />
           </Stack>
 
-          <Box ml={ 2.5 } mt={ 3.5 }>
+          <Box ml={ 2.5 } mt={ 2.5 }>
             <SideBarHeader>MY SETTINGS</SideBarHeader>
           </Box>
 
@@ -221,7 +221,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
             />
           </Stack>
 
-          <Box ml={ 2.5 } mt={ 4 }>
+          <Box ml={ 2.5 } mt={ 2.5 }>
             <SideBarHeader>SUPPORT</SideBarHeader>
           </Box>
 
@@ -257,7 +257,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
         <Box
           bottom={ 0 }
           className="referral-banner"
-          mb={ 2 }
+          mb={ 1 }
           mt="auto"
           mx={ -1 }
           position={ !isReferralBannerDismissed ? "sticky" : undefined }


### PR DESCRIPTION
Update:

- Remove copy from Referral Banner component that was visible after a successful referral had occured. Leaving only the Invite an Artist button.

- Update sidebar spacing to fit the button in the full view and avoid scroll bars.

<img width="227" height="949" alt="image" src="https://github.com/user-attachments/assets/44f7be23-2851-4f88-b696-b4b974c16333" />
