### PR TITLE
STUD-496: Update width of 404 error "Page Not Found" webpage.

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -154,8 +154,14 @@ const App = () => {
                         path="create-profile/*"
                       />
 
-                      { /* Catch-all route for 404 Page Not Found */ }
-                      <Route element={ <NotFoundPage /> } path="*" />
+                      <Route
+                        element={
+                          <PrivateRoute>
+                            <NotFoundPage />
+                          </PrivateRoute>
+                        }
+                        path="*"
+                      />
                     </Routes>
                   </BrowserRouter>
                 </Background>

--- a/apps/studio/src/pages/NotFoundPage.tsx
+++ b/apps/studio/src/pages/NotFoundPage.tsx
@@ -13,6 +13,7 @@ const NotFoundPage: FunctionComponent<NotFoundPageProps> = ({
   return (
     <PageNotFound
       layout="sidebar"
+      originAppName="Studio"
       redirectUrl={ redirectUrl }
       onNavigate={ (url) => navigate(url) }
     />

--- a/packages/components/src/lib/PageNotFound.tsx
+++ b/packages/components/src/lib/PageNotFound.tsx
@@ -8,6 +8,7 @@ import { Button } from "@newm-web/elements";
 interface PageNotFoundProps {
   readonly layout?: "sidebar" | "topbar";
   readonly onNavigate?: (url: string) => void;
+  readonly originAppName?: "Studio" | "Marketplace";
   readonly redirectUrl?: string;
 }
 
@@ -15,6 +16,7 @@ const PageNotFound: FunctionComponent<PageNotFoundProps> = ({
   redirectUrl = "/",
   onNavigate,
   layout = "topbar",
+  originAppName,
 }) => {
   const handleGoBack = () => {
     if (onNavigate) {
@@ -101,7 +103,7 @@ const PageNotFound: FunctionComponent<PageNotFoundProps> = ({
       </Stack>
 
       <Button sx={ { mt: 2.5 } } width="compact" onClick={ handleGoBack }>
-        Back to NEWM
+        Back to NEWM{ originAppName ? ` ${originAppName}` : "" }
       </Button>
       <Box
         alt="NEWM Monster"

--- a/packages/components/src/lib/PageNotFound.tsx
+++ b/packages/components/src/lib/PageNotFound.tsx
@@ -15,7 +15,7 @@ interface PageNotFoundProps {
 const PageNotFound: FunctionComponent<PageNotFoundProps> = ({
   redirectUrl = "/",
   onNavigate,
-  layout = "topbar",
+  layout = "sidebar",
   originAppName,
 }) => {
   const handleGoBack = () => {
@@ -42,6 +42,7 @@ const PageNotFound: FunctionComponent<PageNotFoundProps> = ({
         pt: [4, 7.5],
         px: 0.5,
         textAlign: "center" as const,
+        width: "100%",
       } as SxProps,
       imageSpacing: {
         mt: { md: 15, xs: 0 },


### PR DESCRIPTION
Fixes:
- If user not logged in, and lands on an invalid url, user is redirected to login page
- If user is already logged in but navigates to a top level invalid url, the user is redirect to page not found, the width of the 404 page now covers the entire page
- The button copy on page not found is updated to include "Studio"



https://github.com/user-attachments/assets/ebb78564-6e78-44da-9e45-c96f8453e278



[STUD-496](https://projectnewm.atlassian.net/browse/STUD-496)

[STUD-496]: https://projectnewm.atlassian.net/browse/STUD-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ