### PR TITLE
STUD-512: displays error message when Cloudinary upload fails

### DIFF
--- a/apps/studio/src/api/cloudinary/api.ts
+++ b/apps/studio/src/api/cloudinary/api.ts
@@ -22,7 +22,7 @@ const api = createApi({
           // Replace generic message with API error message if present
           if (error && typeof error === "object" && "error" in error) {
             const apiError = error as CloudinaryError;
-            const apiErrorMessage = apiError.error.data.error.message;
+            const apiErrorMessage = apiError.error.data?.error?.message;
 
             if (apiErrorMessage) {
               message = apiErrorMessage;

--- a/apps/studio/src/api/cloudinary/api.ts
+++ b/apps/studio/src/api/cloudinary/api.ts
@@ -1,7 +1,8 @@
 import { createApi } from "@reduxjs/toolkit/query/react";
-import { axiosBaseQuery } from "@newm-web/utils";
+import { CloudinaryError, axiosBaseQuery } from "@newm-web/utils";
 import { CloudinaryUploadParams, CloudinaryUploadResponse } from "./types";
 import { baseUrls } from "../../buildParams";
+import { setToastMessage } from "../../modules/ui";
 
 const api = createApi({
   baseQuery: axiosBaseQuery({
@@ -12,6 +13,31 @@ const api = createApi({
       CloudinaryUploadResponse,
       CloudinaryUploadParams
     >({
+      async onQueryStarted(body, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled;
+        } catch (error) {
+          let message = "There was an error uploading your image";
+
+          // Replace generic message with API error message if present
+          if (error && typeof error === "object" && "error" in error) {
+            const apiError = error as CloudinaryError;
+            const apiErrorMessage = apiError.error.data.error.message;
+
+            if (apiErrorMessage) {
+              message = apiErrorMessage;
+            }
+          }
+
+          dispatch(
+            setToastMessage({
+              message,
+              severity: "error",
+            })
+          );
+        }
+      },
+
       query: ({ onUploadProgress, ...body }) => ({
         body,
         method: "POST",

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -32,9 +32,9 @@ export type CustomError = {
 
 export type CloudinaryError = {
   error: {
-    data: {
-      error: {
-        message: string;
+    data?: {
+      error?: {
+        message?: string;
       };
     };
   };

--- a/packages/utils/src/lib/types.ts
+++ b/packages/utils/src/lib/types.ts
@@ -30,6 +30,16 @@ export type CustomError = {
   status: number;
 };
 
+export type CloudinaryError = {
+  error: {
+    data: {
+      error: {
+        message: string;
+      };
+    };
+  };
+};
+
 export interface EmptyResponse {
   readonly data: null;
 }


### PR DESCRIPTION
Updates the Cloudinary API upload image endpoint to display an toast with an error message if it fails.

<img width="540" height="81" alt="Screen Shot 2025-10-28 at 2 28 51 AM" src="https://github.com/user-attachments/assets/8b3af6cd-c061-41ad-9fcd-5d7530136a5c" />
