### PR TITLE
STUD-504: Update Release Summary (now Order Summary) modal based on copy feedback.

### DIFF
--- a/apps/studio/src/pages/home/uploadSong/ConfirmAgreement.tsx
+++ b/apps/studio/src/pages/home/uploadSong/ConfirmAgreement.tsx
@@ -5,7 +5,7 @@ import { useWindowDimensions } from "@newm-web/utils";
 import { Button } from "@newm-web/elements";
 import { useFlags } from "launchdarkly-react-client-sdk";
 import PriceSummaryDialog from "./PriceSummaryDialog";
-import ReleaseSummaryDialog from "./ReleaseSummaryDialog";
+import OrderSummaryDialog from "./OrderSummaryDialog";
 import { UploadSongThunkRequest } from "../../../modules/song";
 import { ConfirmContract } from "../../../components";
 
@@ -73,7 +73,7 @@ const ConfirmAgreement: FunctionComponent<ConfirmAgreementProps> = ({
 
         { shouldShowPriceSummary &&
           (webStudioReleaseDistributionPaymentEnhancements ? (
-            <ReleaseSummaryDialog
+            <OrderSummaryDialog
               open={ isPaymentSummaryOpen }
               onClose={ () => setIsPaymentSummaryOpen(false) }
             />

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -68,6 +68,11 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
     (option) => option.paymentType === values.paymentType
   );
 
+  const royaltySplitFeePerCollab = formatUsdAmount(
+    Number(songEstimatePrices?.collabPricePerArtistUsd),
+    { precision: 2, returnZeroValue: false }
+  );
+
   const newmUsdConversionRate = newmiesUsdConversionRate / LOVELACE_CONVERSION;
 
   const convertUsdToNewm = (usdValue?: string) => {
@@ -383,7 +388,6 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                   ) }
                 </Stack>
               </Stack>
-
               <Stack direction="row" justifyContent="space-between">
                 <Typography
                   sx={ {
@@ -391,15 +395,31 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                     fontWeight: theme.typography.fontWeightRegular,
                   } }
                 >
-                  Stream Token minting
+                  Royalty split(s) fee
+                  <Tooltip
+                    title={
+                      "As previously mentioned during the upload process, an " +
+                      `additional ${royaltySplitFeePerCollab} fee is ` +
+                      "required to transfer streaming rights to each royalty " +
+                      "split holder."
+                    }
+                  >
+                    <IconButton sx={ { ml: 0.5, padding: 0 } }>
+                      <HelpIcon
+                        sx={ {
+                          color: theme.colors.grey200,
+                        } }
+                      />
+                    </IconButton>
+                  </Tooltip>
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   {
                     <Typography variant="subtitle2">
-                      ({ displayPrices.mintPriceNewm })
+                      ({ displayPrices.collabPriceNewm })
                     </Typography>
                   }
-                  <Typography>{ displayPrices.mintPriceUsd }</Typography>
+                  <Typography>{ displayPrices.collabPriceUsd }</Typography>
                 </Stack>
               </Stack>
 
@@ -410,15 +430,28 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                     fontWeight: theme.typography.fontWeightRegular,
                   } }
                 >
-                  Royalty splits
+                  Service fee
+                  <Tooltip
+                    title={
+                      "This fee covers the cost of digital contract creation."
+                    }
+                  >
+                    <IconButton sx={ { ml: 0.5, padding: 0 } }>
+                      <HelpIcon
+                        sx={ {
+                          color: theme.colors.grey200,
+                        } }
+                      />
+                    </IconButton>
+                  </Tooltip>
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   {
                     <Typography variant="subtitle2">
-                      ({ displayPrices.collabPriceNewm })
+                      ({ displayPrices.mintPriceNewm })
                     </Typography>
                   }
-                  <Typography>{ displayPrices.collabPriceUsd }</Typography>
+                  <Typography>{ displayPrices.mintPriceUsd }</Typography>
                 </Stack>
               </Stack>
             </Stack>

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -15,11 +15,7 @@ import {
 import HelpIcon from "@mui/icons-material/Help";
 import { Button, Dialog, HorizontalLine, Tooltip } from "@newm-web/elements";
 import theme from "@newm-web/theme";
-import {
-  LOVELACE_CONVERSION,
-  formatNewmAmount,
-  formatUsdAmount,
-} from "@newm-web/utils";
+import { formatNewmAmount, formatUsdAmount } from "@newm-web/utils";
 import { Charli3Logo, CheckCircleRadioIcon } from "@newm-web/assets";
 import { PaymentType } from "@newm-web/types";
 import {
@@ -61,9 +57,6 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
       }
     );
 
-  const { data: { usdPrice: newmiesUsdConversionRate = 0 } = {} } =
-    useGetNewmUsdConversionRateQuery();
-
   const songEstimatePrices = songEstimate?.mintPaymentOptions?.find(
     (option) => option.paymentType === values.paymentType
   );
@@ -73,24 +66,12 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
     { precision: 2, returnZeroValue: false }
   );
 
-  const newmUsdConversionRate = newmiesUsdConversionRate / LOVELACE_CONVERSION;
-
-  const convertUsdToNewm = (usdValue?: string) => {
-    if (!usdValue || !newmUsdConversionRate) return undefined;
-    return Number(usdValue) / newmUsdConversionRate;
-  };
-
   const displayPrices = {
-    collabPriceNewm: formatNewmAmount(
-      isPaypalPayment
-        ? Number(convertUsdToNewm(songEstimatePrices?.collabPrice))
-        : Number(songEstimatePrices?.collabPrice),
-      {
-        includeEstimateSymbol: true,
-        precision: 2,
-        returnZeroValue: false,
-      }
-    ),
+    collabPriceNewm: formatNewmAmount(Number(songEstimatePrices?.collabPrice), {
+      includeEstimateSymbol: true,
+      precision: 0,
+      returnZeroValue: false,
+    }),
     collabPriceUsd: formatUsdAmount(
       Number(songEstimatePrices?.collabPriceUsd),
       {
@@ -98,44 +79,29 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
         returnZeroValue: false,
       }
     ),
-    dspPriceNewm: formatNewmAmount(
-      isPaypalPayment
-        ? Number(convertUsdToNewm(songEstimatePrices?.dspPrice))
-        : Number(songEstimatePrices?.dspPrice),
-      {
-        includeEstimateSymbol: true,
-        precision: 2,
-        returnZeroValue: false,
-      }
-    ),
+    dspPriceNewm: formatNewmAmount(Number(songEstimatePrices?.dspPrice), {
+      includeEstimateSymbol: true,
+      precision: 0,
+      returnZeroValue: false,
+    }),
     dspPriceUsd: formatUsdAmount(Number(songEstimatePrices?.dspPriceUsd), {
       precision: 2,
       returnZeroValue: false,
     }),
-    mintPriceNewm: formatNewmAmount(
-      isPaypalPayment
-        ? Number(convertUsdToNewm(songEstimatePrices?.mintPrice))
-        : Number(songEstimatePrices?.mintPrice),
-      {
-        includeEstimateSymbol: true,
-        precision: 2,
-        returnZeroValue: false,
-      }
-    ),
+    mintPriceNewm: formatNewmAmount(Number(songEstimatePrices?.mintPrice), {
+      includeEstimateSymbol: true,
+      precision: 0,
+      returnZeroValue: false,
+    }),
     mintPriceUsd: formatUsdAmount(Number(songEstimatePrices?.mintPriceUsd), {
       precision: 2,
       returnZeroValue: false,
     }),
-    priceNewm: formatNewmAmount(
-      isPaypalPayment
-        ? Number(convertUsdToNewm(songEstimatePrices?.price))
-        : Number(songEstimatePrices?.price),
-      {
-        includeEstimateSymbol: true,
-        precision: 2,
-        returnZeroValue: false,
-      }
-    ),
+    priceNewm: formatNewmAmount(Number(songEstimatePrices?.price), {
+      includeEstimateSymbol: true,
+      precision: 0,
+      returnZeroValue: false,
+    }),
     priceUsd: formatUsdAmount(Number(songEstimatePrices?.priceUsd), {
       precision: 2,
       returnZeroValue: false,
@@ -379,12 +345,7 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                       </Typography>
                     </>
                   ) : (
-                    <>
-                      <Typography variant="subtitle2">
-                        ({ displayPrices.dspPriceNewm })
-                      </Typography>
-                      <Typography>{ displayPrices.dspPriceUsd }</Typography>
-                    </>
+                    <Typography>{ displayPrices.dspPriceUsd }</Typography>
                   ) }
                 </Stack>
               </Stack>
@@ -414,11 +375,11 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                   </Tooltip>
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
-                  {
+                  { isNewmPayment && (
                     <Typography variant="subtitle2">
                       ({ displayPrices.collabPriceNewm })
                     </Typography>
-                  }
+                  ) }
                   <Typography>{ displayPrices.collabPriceUsd }</Typography>
                 </Stack>
               </Stack>
@@ -446,11 +407,11 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                   </Tooltip>
                 </Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
-                  {
+                  { isNewmPayment && (
                     <Typography variant="subtitle2">
                       ({ displayPrices.mintPriceNewm })
                     </Typography>
-                  }
+                  ) }
                   <Typography>{ displayPrices.mintPriceUsd }</Typography>
                 </Stack>
               </Stack>
@@ -468,19 +429,21 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
               <Stack direction="row" justifyContent="space-between">
                 <Typography>Total</Typography>
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
-                  {
+                  { isNewmPayment && (
                     <Typography variant="subtitle2">
                       ({ displayPrices.priceNewm })
                     </Typography>
-                  }
+                  ) }
                   <Typography>{ displayPrices.priceUsd }</Typography>
                 </Stack>
               </Stack>
             </Stack>
           </Stack>
           <Typography mt={ 0.5 } variant="subtitle2">
-            Total does not include the Cardano blockchain network fee. Fee
-            prices are not guaranteed, costs may vary.
+            { isNewmPayment
+              ? "Total does not include the blockchain network fee. Fee " +
+                "prices are not guaranteed, costs may vary."
+              : "Fee prices are not guaranteed, costs may vary." }
           </Typography>
         </Stack>
       </DialogContent>

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -28,12 +28,12 @@ import {
 import { useGetNewmUsdConversionRateQuery } from "../../../modules/crypto";
 import { openPayPalPopup } from "../../../common/paypalUtils";
 
-interface ReleaseSummaryDialogProps {
+interface OrderSummaryDialogProps {
   readonly onClose: () => void;
   readonly open: boolean;
 }
 
-const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
+const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
   open,
   onClose,
 }) => {
@@ -164,7 +164,7 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
     <Dialog fullWidth={ true } open={ open } onClose={ onClose }>
       <DialogTitle sx={ { pb: 0, pt: 3 } }>
         <Typography fontSize={ 20 } fontWeight={ 800 } variant="body2">
-          Release Summary
+          Order Summary
         </Typography>
       </DialogTitle>
 
@@ -492,4 +492,4 @@ const ReleaseSummaryDialog: FunctionComponent<ReleaseSummaryDialogProps> = ({
   );
 };
 
-export default ReleaseSummaryDialog;
+export default OrderSummaryDialog;

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -6,12 +6,14 @@ import {
   DialogTitle,
   FormControl,
   FormControlLabel,
+  IconButton,
   Radio,
   RadioGroup,
   Stack,
   Typography,
 } from "@mui/material";
-import { Button, Dialog, HorizontalLine } from "@newm-web/elements";
+import HelpIcon from "@mui/icons-material/Help";
+import { Button, Dialog, HorizontalLine, Tooltip } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 import {
   LOVELACE_CONVERSION,
@@ -283,7 +285,7 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                     fontWeight: theme.typography.fontWeightRegular,
                   } }
                 >
-                  Release name
+                  Release title
                 </Typography>
                 <Typography>{ values.title }</Typography>
               </Stack>
@@ -293,9 +295,23 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                   sx={ {
                     color: theme.colors.grey200,
                     fontWeight: theme.typography.fontWeightRegular,
+                    gap: 1,
                   } }
                 >
                   Number of collaborators
+                  <Tooltip
+                    title={
+                      "This is the total number of collaborators, including yourself."
+                    }
+                  >
+                    <IconButton sx={ { ml: 0.5, padding: 0 } }>
+                      <HelpIcon
+                        sx={ {
+                          color: theme.colors.grey200,
+                        } }
+                      />
+                    </IconButton>
+                  </Tooltip>
                 </Typography>
                 <Typography>{ values.owners.length }</Typography>
               </Stack>

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -162,10 +162,8 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
 
   return (
     <Dialog fullWidth={ true } open={ open } onClose={ onClose }>
-      <DialogTitle sx={ { pb: 0, pt: 3 } }>
-        <Typography fontSize={ 20 } fontWeight={ 800 } variant="body2">
-          Order Summary
-        </Typography>
+      <DialogTitle sx={ { pb: 0, pt: 3 } } variant="body2">
+        Order Summary
       </DialogTitle>
 
       <DialogContent sx={ { pb: 2, px: 3 } }>

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -258,15 +258,17 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                 >
                   Release title
                 </Typography>
+
                 <Typography>{ values.title }</Typography>
               </Stack>
 
               <Stack direction="row" justifyContent="space-between">
                 <Typography
                   sx={ {
+                    alignItems: "center",
                     color: theme.colors.grey200,
+                    display: "inline-flex",
                     fontWeight: theme.typography.fontWeightRegular,
-                    gap: 1,
                   } }
                 >
                   Number of collaborators
@@ -278,12 +280,15 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                     <IconButton sx={ { ml: 0.5, padding: 0 } }>
                       <HelpIcon
                         sx={ {
-                          color: theme.colors.grey200,
+                          color: theme.colors.grey100,
+                          height: "18px",
+                          width: "18px",
                         } }
                       />
                     </IconButton>
                   </Tooltip>
                 </Typography>
+
                 <Typography>{ values.owners.length }</Typography>
               </Stack>
 
@@ -296,6 +301,7 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                 >
                   Release date
                 </Typography>
+
                 <Typography>
                   { values.releaseDate
                     ? new Date(values.releaseDate).toLocaleDateString()
@@ -323,6 +329,7 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                 >
                   Distribution cost
                 </Typography>
+
                 <Stack direction={ "row" } gap={ 1 }>
                   { isNewmPayment ? (
                     <>
@@ -352,7 +359,9 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
               <Stack direction="row" justifyContent="space-between">
                 <Typography
                   sx={ {
+                    alignItems: "center",
                     color: theme.colors.grey200,
+                    display: "inline-flex",
                     fontWeight: theme.typography.fontWeightRegular,
                   } }
                 >
@@ -368,12 +377,15 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                     <IconButton sx={ { ml: 0.5, padding: 0 } }>
                       <HelpIcon
                         sx={ {
-                          color: theme.colors.grey200,
+                          color: theme.colors.grey100,
+                          height: "18px",
+                          width: "18px",
                         } }
                       />
                     </IconButton>
                   </Tooltip>
                 </Typography>
+
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { isNewmPayment && (
                     <Typography variant="subtitle2">
@@ -387,7 +399,9 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
               <Stack direction="row" justifyContent="space-between">
                 <Typography
                   sx={ {
+                    alignItems: "center",
                     color: theme.colors.grey200,
+                    display: "inline-flex",
                     fontWeight: theme.typography.fontWeightRegular,
                   } }
                 >
@@ -400,12 +414,15 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
                     <IconButton sx={ { ml: 0.5, padding: 0 } }>
                       <HelpIcon
                         sx={ {
-                          color: theme.colors.grey200,
+                          color: theme.colors.grey100,
+                          height: "18px",
+                          width: "18px",
                         } }
                       />
                     </IconButton>
                   </Tooltip>
                 </Typography>
+
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { isNewmPayment && (
                     <Typography variant="subtitle2">
@@ -428,6 +445,7 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
             >
               <Stack direction="row" justifyContent="space-between">
                 <Typography>Total</Typography>
+
                 <Stack alignItems="center" direction={ "row" } gap={ 1 }>
                   { isNewmPayment && (
                     <Typography variant="subtitle2">


### PR DESCRIPTION
Rename the Release Summary dialog to Order Summary and enhance accessibility and consistency in the dialog's title. Update the copy in the order summary to align with the latest design specifications, including tooltips for collaborators and fees. Remove unnecessary currency conversion logic and adjust the display of fees for clarity.

$NEWM Updated Order Summary:
<img width="643" height="545" alt="Updated Copy Order Summary - NEWM" src="https://github.com/user-attachments/assets/17450528-6e29-4a8d-996f-729ec1365f76" />


PayPal Updated Order Summary:
<img width="643" height="545" alt="Updated Copy Order Summary - PayPal" src="https://github.com/user-attachments/assets/79adc3be-0817-4eef-a8db-cf5a7d93dc36" />


[STUD-504](https://projectnewm.atlassian.net/browse/STUD-504)

[STUD-504]: https://projectnewm.atlassian.net/browse/STUD-504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ