### PR TITLE
STUD-508: Update custom PayPal checkout windows copy.

### DIFF
--- a/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent, useEffect } from "react";
 import { Stack, Typography } from "@mui/material";
-import { Button, GradientTypography } from "@newm-web/elements";
+import { GradientTypography } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 
 const PayPalSuccessSession: FunctionComponent = () => {

--- a/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
+++ b/apps/studio/src/components/paypal/PayPalSuccessSession.tsx
@@ -17,21 +17,15 @@ const PayPalSuccessSession: FunctionComponent = () => {
         justifyContent: "center",
       } }
     >
-      <Typography variant="h1">THANK YOU!</Typography>
+      <Typography textTransform={ "uppercase" } variant="h1">
+        Payment Complete!
+      </Typography>
       <GradientTypography
         style={ { ...theme.typography.emphasized, textAlign: "center" } }
         variant="h1"
       >
-        Heading back to the upload process.
+        Heading back to your Library.
       </GradientTypography>
-      <Typography
-        sx={ {
-          fontWeight: 400,
-          my: [2, 3, 4],
-        } }
-      >
-        Get ready to share your music and to claim royalties.
-      </Typography>
     </Stack>
   );
 };


### PR DESCRIPTION
Revise the text displayed in the PayPal Payment success session window that appears after a PayPal payment.

<img width="491" height="461" alt="image" src="https://github.com/user-attachments/assets/e4deb155-bf39-4bc9-b9ce-f6d49438076d" />

[STUD-508](https://projectnewm.atlassian.net/browse/STUD-508)



[STUD-508]: https://projectnewm.atlassian.net/browse/STUD-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ