### PR TITLE
STUD-424: Add FAQ Outlet URL to NEWM Studio distribution pricing modal copy

### DIFF
--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -11,7 +11,7 @@ export const NEWM_STUDIO_DISCORD_URL =
   "https://discord.com/channels/931903540056694856/1153293933468713041";
 export const NEWM_STUDIO_FAQ_URL = "https://newm.io/artist-faq";
 export const NEWM_STUDIO_TELEGRAM_URL = "https://t.me/NEWMartists";
-export const NEWM_STUDIO_OUTLETS_URL = "https://newm.io/faq/#outlets";
+export const NEWM_STUDIO_OUTLETS_URL = "https://newm.io/artist-faq/#outlets";
 export const NEWM_PRIVACY_POLICY_URL = "https://newm.io/privacy-policy/";
 /**
  * Character count constants for form validation

--- a/apps/studio/src/components/dspPricing/DistributionPricingDialog.tsx
+++ b/apps/studio/src/components/dspPricing/DistributionPricingDialog.tsx
@@ -6,12 +6,14 @@ import {
   DialogActions,
   DialogContent,
   Divider,
+  Link,
   Stack,
   Typography,
 } from "@mui/material";
 import { Check } from "@mui/icons-material";
 import { LocalStorageKey, PaymentType } from "@newm-web/types";
 import { FunctionComponent } from "react";
+import { NEWM_STUDIO_OUTLETS_URL } from "../../common/constants";
 import { useUpdateProfileThunk } from "../../modules/session";
 import { useGetMintSongEstimateQuery } from "../../modules/song";
 
@@ -24,6 +26,10 @@ interface DistributionPricingDialogProps {
 /**
  * Allows users to select a pricing plan for music distribution.
  */
+type PricingPlanCriterion = {
+  details: React.ReactNode;
+};
+
 const DistributionPricingDialog: FunctionComponent<
   DistributionPricingDialogProps
 > = ({ onCancel, onConfirm, open }) => {
@@ -49,19 +55,47 @@ const DistributionPricingDialog: FunctionComponent<
     returnZeroValue: false,
   });
 
-  const pricingPlanCriteria = [
-    { text: "Distribute your music to 130+ global platforms" },
+  const pricingPlanCriteria: PricingPlanCriterion[] = [
     {
-      highlight: "20% discount",
-      highlightColor: theme.colors.baseGreen,
-      text: "for paying in $NEWM Tokens",
+      details: (
+        <>
+          Distribute your music to all major platforms
+          <br />
+          { "(" }
+          <Link
+            href={ NEWM_STUDIO_OUTLETS_URL }
+            rel="noopener"
+            sx={ {
+              "&:hover": {
+                textDecoration: "underline",
+              },
+              color: theme.colors.music,
+              textDecoration: "none",
+            } }
+            target="_blank"
+          >
+            view full list
+          </Link>
+          { ")" }
+        </>
+      ),
     },
-    { text: "Automate royalty splits" },
-    { text: "Free EAN Release Code & ISRC generation" },
-    { text: "Add and manage release collaborators" },
-    { text: "Customize your artist profile" },
-    { text: "Track catalog status" },
-    { text: "Sell music rights to your fans on the NEWM Marketplace!" },
+    {
+      details: (
+        <>
+          <Box component="span" sx={ { color: theme.colors.baseGreen } }>
+            20% discount
+          </Box>{ " " }
+          for paying in $NEWM Tokens
+        </>
+      ),
+    },
+    { details: "Automate royalty splits" },
+    { details: "Free EAN Release Code & ISRC generation" },
+    { details: "Add and manage release collaborators" },
+    { details: "Customize your artist profile" },
+    { details: "Track catalog status" },
+    { details: "Sell music rights to your fans on the NEWM Marketplace!" },
   ];
 
   return (
@@ -123,6 +157,7 @@ const DistributionPricingDialog: FunctionComponent<
               <Box
                 key={ index }
                 sx={ {
+                  alignItems: "center",
                   display: "flex",
                   flexDirection: "row",
                   gap: 1.5,
@@ -130,24 +165,8 @@ const DistributionPricingDialog: FunctionComponent<
               >
                 <Check sx={ { color: theme.colors.baseGreen } } />
 
-                <Typography
-                  alignSelf={ "center" }
-                  fontWeight={ 500 }
-                  variant="body1"
-                >
-                  { criterion.highlight ? (
-                    <>
-                      <Box
-                        component="span"
-                        sx={ { color: criterion.highlightColor } }
-                      >
-                        { criterion.highlight }
-                      </Box>
-                      { " " + criterion.text }
-                    </>
-                  ) : (
-                    criterion.text
-                  ) }
+                <Typography fontWeight={ 500 } variant="body1">
+                  { criterion.details }
                 </Typography>
               </Box>
             )) }

--- a/apps/studio/src/components/dspPricing/test/DistributionPricingDialog.test.tsx
+++ b/apps/studio/src/components/dspPricing/test/DistributionPricingDialog.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, waitFor } from "@testing-library/react";
 import { LocalStorage } from "@newm-web/utils";
 import { LocalStorageKey, PaymentType } from "@newm-web/types";
-import { renderWithContext } from "../../../common";
+import { NEWM_STUDIO_OUTLETS_URL, renderWithContext } from "../../../common";
 import * as sessionModule from "../../../modules/session";
 /**
  * Note: DistributionPricingDialog must be imported AFTER renderWithContext.
@@ -88,7 +88,7 @@ describe("<DistributionPricingDialog />", () => {
     });
 
     it("renders all pricing criteria", () => {
-      const { getByText } = renderWithContext(
+      const { getByText, getByRole } = renderWithContext(
         <DistributionPricingDialog
           open={ true }
           onCancel={ mockOnCancel }
@@ -96,16 +96,19 @@ describe("<DistributionPricingDialog />", () => {
         />
       );
 
+      // Normal details with a link at the end
       expect(
-        getByText("Distribute your music to 130+ global platforms")
+        getByText(/Distribute your music to all major platforms/)
       ).toBeInTheDocument();
+      const viewFullListLink = getByRole("link", { name: "view full list" });
+      expect(viewFullListLink).toBeInTheDocument();
+      expect(viewFullListLink).toHaveAttribute("href", NEWM_STUDIO_OUTLETS_URL);
 
-      // These next two parts will be different styles
-      const discountText = getByText("20% discount");
-      expect(discountText).toBeInTheDocument();
-      expect(discountText.nextSibling?.textContent ?? "").toContain(
-        "for paying in $NEWM Tokens"
-      );
+      // highlighted text for the first part and normal details followed
+      expect(getByText("20% discount")).toBeInTheDocument();
+      expect(getByText(/for paying in \$NEWM Tokens/)).toBeInTheDocument();
+
+      // All other details are normal text
       expect(getByText("Automate royalty splits")).toBeInTheDocument();
       expect(
         getByText("Free EAN Release Code & ISRC generation")


### PR DESCRIPTION
Update the `NEWM_STUDIO_OUTLETS_URL` to point to the latest FAQ section with Outlet anchor. Enhance the `DistributionPricingDialog` to include a link to the full list of distribution outlets in the pricing plan criteria. Refactor criteria details to handle custom designs for links and highlights.

<img width="475" height="707" alt="image" src="https://github.com/user-attachments/assets/f202d170-b6c0-453f-9e17-f235cd181fda" />

[STUD-424](https://projectnewm.atlassian.net/browse/STUD-424)

[STUD-424]: https://projectnewm.atlassian.net/browse/STUD-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ