### PR TITLE
STUD-532: Update first and last name validation to 50 characters

### DIFF
--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -16,6 +16,7 @@ export const NEWM_PRIVACY_POLICY_URL = "https://newm.io/privacy-policy/";
 /**
  * Character count constants for form validation
  */
+export const OFFICIAL_NAME_MAX_CHARACTER_COUNT = 50;
 export const MAX_CHARACTER_COUNT = 64;
 export const SONG_DESCRIPTION_MAX_CHARACTER_COUNT = 120;
 export const MAX_CHARACTER_COUNT_LONG = 250;

--- a/apps/studio/src/common/formUtils.ts
+++ b/apps/studio/src/common/formUtils.ts
@@ -21,6 +21,7 @@ import {
   MAX_CHARACTER_COUNT,
   MIN_DISTRIBUTION_TIME,
   NONE_OPTION,
+  OFFICIAL_NAME_MAX_CHARACTER_COUNT,
   SONG_DESCRIPTION_MAX_CHARACTER_COUNT,
 } from "./constants";
 
@@ -121,8 +122,8 @@ export const commonYupValidation = {
   firstName: Yup.string()
     .trim()
     .max(
-      MAX_CHARACTER_COUNT,
-      `Must be ${MAX_CHARACTER_COUNT} characters or less`
+      OFFICIAL_NAME_MAX_CHARACTER_COUNT,
+      `Must be ${OFFICIAL_NAME_MAX_CHARACTER_COUNT} characters or less`
     )
     .required("First name is required"),
   genre: (genreOptions: string[]) =>
@@ -169,8 +170,8 @@ export const commonYupValidation = {
   lastName: Yup.string()
     .trim()
     .max(
-      MAX_CHARACTER_COUNT,
-      `Must be ${MAX_CHARACTER_COUNT} characters or less`
+      OFFICIAL_NAME_MAX_CHARACTER_COUNT,
+      `Must be ${OFFICIAL_NAME_MAX_CHARACTER_COUNT} characters or less`
     )
     .required("Last name is required"),
   location: Yup.string().required("This field is required"),

--- a/apps/studio/src/common/formUtils.ts
+++ b/apps/studio/src/common/formUtils.ts
@@ -120,7 +120,10 @@ export const commonYupValidation = {
     .required("Email is required"),
   firstName: Yup.string()
     .trim()
-    .max(15, "Must be 15 characters or less")
+    .max(
+      MAX_CHARACTER_COUNT,
+      `Must be ${MAX_CHARACTER_COUNT} characters or less`
+    )
     .required("First name is required"),
   genre: (genreOptions: string[]) =>
     Yup.string().test(
@@ -165,7 +168,10 @@ export const commonYupValidation = {
   ),
   lastName: Yup.string()
     .trim()
-    .max(20, "Must be 20 characters or less")
+    .max(
+      MAX_CHARACTER_COUNT,
+      `Must be ${MAX_CHARACTER_COUNT} characters or less`
+    )
     .required("Last name is required"),
   location: Yup.string().required("This field is required"),
   moods: Yup.array().max(5, "Maximum of 5 moods allowed"),


### PR DESCRIPTION
Adjust validation limits for first and last names to a maximum of 50 characters, aligning with EVEARA's requirements. Prevent Logic/UI issue that occurs with names longer than current limits.

[STUD-532](https://projectnewm.atlassian.net/browse/STUD-532)

[STUD-532]: https://projectnewm.atlassian.net/browse/STUD-532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ