### PR TITLE
STUD-523: Fix listing for Royalty Split(s) fee with value of N/A

### DIFF
--- a/apps/studio/src/components/dspPricing/DistributionPricingDialog.tsx
+++ b/apps/studio/src/components/dspPricing/DistributionPricingDialog.tsx
@@ -52,7 +52,7 @@ const DistributionPricingDialog: FunctionComponent<
 
   const dspFormattedPricingUsd = formatUsdAmount(Number(dspPriceUsd), {
     precision: 2,
-    returnZeroValue: false,
+    returnZeroValueForNullish: false,
   });
 
   const pricingPlanCriteria: PricingPlanCriterion[] = [

--- a/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
+++ b/apps/studio/src/pages/home/uploadSong/OrderSummaryDialog.tsx
@@ -65,48 +65,48 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
 
   const royaltySplitFeePerCollab = formatUsdAmount(
     Number(songEstimatePrices?.collabPricePerArtistUsd),
-    { precision: 2, returnZeroValue: false }
+    { precision: 2, returnZeroValueForNullish: false }
   );
 
   const displayPrices = {
     collabPriceNewm: formatNewmAmount(Number(songEstimatePrices?.collabPrice), {
       includeEstimateSymbol: true,
       precision: 0,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
     collabPriceUsd: formatUsdAmount(
       Number(songEstimatePrices?.collabPriceUsd),
       {
         precision: 2,
-        returnZeroValue: false,
+        returnZeroValueForNullish: false,
       }
     ),
     dspPriceNewm: formatNewmAmount(Number(songEstimatePrices?.dspPrice), {
       includeEstimateSymbol: true,
       precision: 0,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
     dspPriceUsd: formatUsdAmount(Number(songEstimatePrices?.dspPriceUsd), {
       precision: 2,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
     mintPriceNewm: formatNewmAmount(Number(songEstimatePrices?.mintPrice), {
       includeEstimateSymbol: true,
       precision: 0,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
     mintPriceUsd: formatUsdAmount(Number(songEstimatePrices?.mintPriceUsd), {
       precision: 2,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
     priceNewm: formatNewmAmount(Number(songEstimatePrices?.price), {
       includeEstimateSymbol: true,
       precision: 0,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
     priceUsd: formatUsdAmount(Number(songEstimatePrices?.priceUsd), {
       precision: 2,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }),
   };
 
@@ -118,7 +118,7 @@ const OrderSummaryDialog: FunctionComponent<OrderSummaryDialogProps> = ({
     ),
     {
       precision: 2,
-      returnZeroValue: false,
+      returnZeroValueForNullish: false,
     }
   );
 

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -12,36 +12,41 @@ interface FormatCurrencyOptions {
   readonly includeCurrencySymbol?: boolean;
   readonly includeEstimateSymbol?: boolean;
   readonly precision?: number;
-  readonly returnZeroValue?: boolean;
+  readonly returnZeroValueForNullish?: boolean;
 }
 
 /**
- * Formats a numerical NEWM amount with three decimal
- * places and the correct symbol.
+ * Formats a numerical NEWM amount with three decimal places and the correct symbol.
  * @param amount - The amount to format
  * @param options - Format options
- * @param options.precision - Number of decimal places (default: 3)
+ * @param options.precision - Number of decimal places, if not explicitly set, amount of 0 will be "Ɲ0" (default: 3)
  * @param options.includeCurrencySymbol - Include currency symbol "Ɲ" (default: true)
  * @param options.includeEstimateSymbol - Include estimate symbol "≈" (default: false)
- * @param options.returnZeroValue - Return "Ɲ0" instead of "N/A" (default: true)
+ * @param options.returnZeroValueForNullish - Return "Ɲ0" instead of "N/A" (default: true)
  */
 export const formatNewmAmount = (
-  amount?: number,
+  amount: number,
   options?: FormatCurrencyOptions
 ) => {
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 3,
-    returnZeroValue = true,
+    returnZeroValueForNullish = true,
   } = options ?? {};
 
-  if (!amount) {
-    if (returnZeroValue) {
+  const isPrecisionExplicit = options?.precision !== undefined;
+
+  if (!amount && amount !== 0) {
+    if (returnZeroValueForNullish) {
       return "Ɲ0";
     } else {
       return "N/A";
     }
+  }
+
+  if (!isPrecisionExplicit && amount === 0) {
+    return includeCurrencySymbol ? "Ɲ0" : "0";
   }
 
   if (precision === 3 && amount < 0.001 && amount > 0) {
@@ -58,32 +63,37 @@ export const formatNewmAmount = (
 };
 
 /**
- * Formats a numerical ADA amount with the correct decimal
- * places and symbol.
+ * Formats a numerical ADA amount with the correct decimal places and symbol.
  * @param amount - The amount to format
  * @param options - Format options
- * @param options.precision - Number of decimal places (default: 2)
+ * @param options.precision - Number of decimal places, if not explicitly set, amount of 0 will be "₳0" (default: 2)
  * @param options.includeCurrencySymbol - Include currency symbol "₳" (default: true)
  * @param options.includeEstimateSymbol - Include estimate symbol "≈" (default: false)
- * @param options.returnZeroValue - Return "₳0" instead of "N/A" (default: true)
+ * @param options.returnZeroValueForNullish - Return "₳0" instead of "N/A" (default: true)
  */
 export const formatAdaAmount = (
-  amount?: number,
+  amount: number,
   options?: FormatCurrencyOptions
 ) => {
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 2,
-    returnZeroValue = true,
+    returnZeroValueForNullish = true,
   } = options ?? {};
 
-  if (!amount) {
-    if (returnZeroValue) {
+  const isPrecisionExplicit = options?.precision !== undefined;
+
+  if (!amount && amount !== 0) {
+    if (returnZeroValueForNullish) {
       return "₳0";
     } else {
       return "N/A";
     }
+  }
+
+  if (!isPrecisionExplicit && amount === 0) {
+    return includeCurrencySymbol ? "₳0" : "0";
   }
 
   const formattedAmount = currency(amount, {
@@ -101,28 +111,34 @@ export const formatAdaAmount = (
  * for NEWM to USD.
  * @param amount - The amount to format
  * @param options - Format options
- * @param options.precision - Number of decimal places (default: 4)
+ * @param options.precision - Number of decimal places, if not explicitly set, amount of 0 will be "$0" (default: 4)
  * @param options.includeCurrencySymbol - Include currency symbol "$" (default: true)
  * @param options.includeEstimateSymbol - Include estimate symbol "≈" (default: false)
- * @param options.returnZeroValue - Return "$0" instead of "N/A" (default: true)
+ * @param options.returnZeroValueForNullish - Return "$0" instead of "N/A" (default: true)
  */
 export const formatUsdAmount = (
-  amount?: number,
+  amount: number,
   options?: FormatCurrencyOptions
 ) => {
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 4,
-    returnZeroValue = true,
+    returnZeroValueForNullish = true,
   } = options ?? {};
 
-  if (!amount) {
-    if (returnZeroValue) {
+  const isPrecisionExplicit = options?.precision !== undefined;
+
+  if (!amount && amount !== 0) {
+    if (returnZeroValueForNullish) {
       return "$0";
     } else {
       return "N/A";
     }
+  }
+
+  if (!isPrecisionExplicit && amount === 0) {
+    return includeCurrencySymbol ? "$0" : "0";
   }
 
   if (precision === 4 && amount < 0.0001 && amount > 0) {

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -18,22 +18,23 @@ interface FormatCurrencyOptions {
 /**
  * Formats a numerical NEWM amount with three decimal
  * places and the correct symbol.
+ * @param amount - The amount to format
+ * @param options - Format options
+ * @param options.precision - Number of decimal places (default: 3)
+ * @param options.includeCurrencySymbol - Include currency symbol "Ɲ" (default: true)
+ * @param options.includeEstimateSymbol - Include estimate symbol "≈" (default: false)
+ * @param options.returnZeroValue - Return "Ɲ0" instead of "N/A" (default: true)
  */
 export const formatNewmAmount = (
   amount?: number,
-  options: FormatCurrencyOptions = {
-    includeCurrencySymbol: true,
-    includeEstimateSymbol: false,
-    precision: 3,
-    returnZeroValue: true,
-  }
+  options?: FormatCurrencyOptions
 ) => {
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 3,
     returnZeroValue = true,
-  } = options;
+  } = options ?? {};
 
   if (!amount) {
     if (returnZeroValue) {
@@ -59,22 +60,23 @@ export const formatNewmAmount = (
 /**
  * Formats a numerical ADA amount with the correct decimal
  * places and symbol.
+ * @param amount - The amount to format
+ * @param options - Format options
+ * @param options.precision - Number of decimal places (default: 2)
+ * @param options.includeCurrencySymbol - Include currency symbol "₳" (default: true)
+ * @param options.includeEstimateSymbol - Include estimate symbol "≈" (default: false)
+ * @param options.returnZeroValue - Return "₳0" instead of "N/A" (default: true)
  */
 export const formatAdaAmount = (
   amount?: number,
-  options: FormatCurrencyOptions = {
-    includeCurrencySymbol: true,
-    includeEstimateSymbol: false,
-    precision: 2,
-    returnZeroValue: true,
-  }
+  options?: FormatCurrencyOptions
 ) => {
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 2,
     returnZeroValue = true,
-  } = options;
+  } = options ?? {};
 
   if (!amount) {
     if (returnZeroValue) {
@@ -97,22 +99,23 @@ export const formatAdaAmount = (
  * Formats a numerical USD amount to four decimal places
  * rather than the standard two, based on the exchange rate
  * for NEWM to USD.
+ * @param amount - The amount to format
+ * @param options - Format options
+ * @param options.precision - Number of decimal places (default: 4)
+ * @param options.includeCurrencySymbol - Include currency symbol "$" (default: true)
+ * @param options.includeEstimateSymbol - Include estimate symbol "≈" (default: false)
+ * @param options.returnZeroValue - Return "$0" instead of "N/A" (default: true)
  */
 export const formatUsdAmount = (
   amount?: number,
-  options: FormatCurrencyOptions = {
-    includeCurrencySymbol: true,
-    includeEstimateSymbol: false,
-    precision: 4,
-    returnZeroValue: true,
-  }
+  options?: FormatCurrencyOptions
 ) => {
   const {
     includeCurrencySymbol = true,
     includeEstimateSymbol = false,
     precision = 4,
     returnZeroValue = true,
-  } = options;
+  } = options ?? {};
 
   if (!amount) {
     if (returnZeroValue) {

--- a/packages/utils/src/lib/crypto.ts
+++ b/packages/utils/src/lib/crypto.ts
@@ -25,7 +25,7 @@ interface FormatCurrencyOptions {
  * @param options.returnZeroValueForNullish - Return "Ɲ0" instead of "N/A" (default: true)
  */
 export const formatNewmAmount = (
-  amount: number,
+  amount?: number,
   options?: FormatCurrencyOptions
 ) => {
   const {
@@ -72,7 +72,7 @@ export const formatNewmAmount = (
  * @param options.returnZeroValueForNullish - Return "₳0" instead of "N/A" (default: true)
  */
 export const formatAdaAmount = (
-  amount: number,
+  amount?: number,
   options?: FormatCurrencyOptions
 ) => {
   const {
@@ -117,7 +117,7 @@ export const formatAdaAmount = (
  * @param options.returnZeroValueForNullish - Return "$0" instead of "N/A" (default: true)
  */
 export const formatUsdAmount = (
-  amount: number,
+  amount?: number,
   options?: FormatCurrencyOptions
 ) => {
   const {


### PR DESCRIPTION
Fix currency formatting functions to better handle nullish values and values of zero in different logic paths. Rename `returnZeroValue` to `returnZeroValueForNullish` to improve true parameter intent. This change improves consistency of how zero values and N/A strings are displayed.

[STUD-523](https://projectnewm.atlassian.net/browse/STUD-523)

[STUD-523]: https://projectnewm.atlassian.net/browse/STUD-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ