### PR TITLE
STUD-522: Switching payment methods after one is cancelled breaks payment process.

### DIFF
--- a/apps/studio/src/modules/song/utils.tsx
+++ b/apps/studio/src/modules/song/utils.tsx
@@ -304,7 +304,10 @@ export const submitMintSongPayment = async (
   const wallet = await enableWallet();
 
   const getPaymentResp = await dispatch(
-    songApi.endpoints.getMintSongPayment.initiate({ paymentType, songId })
+    songApi.endpoints.getMintSongPayment.initiate(
+      { paymentType, songId },
+      { forceRefetch: true }
+    )
   );
 
   if ("error" in getPaymentResp || !getPaymentResp.data) {


### PR DESCRIPTION
Ensure the payment data is always current by forcing a refetch when submitting the mint song payment, resolving issues with outdated cached queries and incorrect backend payment type parameters.

The original ticket focused on other payment and song update glitches, but these glitches can't be reproduced anymore.

This adjacent cached query bug was also blocking payment switching between NEWM and PayPal, and might have been part of the previous glitches.

[STUD-522](https://projectnewm.atlassian.net/browse/STUD-522)

[STUD-522]: https://projectnewm.atlassian.net/browse/STUD-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ