### PR TITLE
[MRKT-209][refactor](artist): Remove black gap on artist page with no banner.

### DIFF
--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -18,7 +18,8 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
 
   const artistBannerUrl = artist?.bannerUrl;
-  const profileHeaderLayout = artistBannerUrl ? "overlay" : "inline";
+  const showBannerArea = isLoading || !!artistBannerUrl;
+  const profileHeaderLayout = showBannerArea ? "overlay" : "inline";
 
   const socials = {
     instagramUrl: artist?.instagramUrl || "",
@@ -37,13 +38,11 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
   return (
     <>
       <Stack direction="column">
-        { artistBannerUrl && (
+        { showBannerArea && (
           <BannerImage imageUrl={ artistBannerUrl } isLoading={ isLoading } />
         ) }
 
-        <Container
-          sx={ { flexGrow: 1, marginTop: artistBannerUrl ? 0 : "3.5rem" } }
-        >
+        <Container sx={ { flexGrow: 1, marginTop: showBannerArea ? 0 : "3.5rem" } }>
           <ProfileHeader
             isLoading={ isLoading }
             isVerified={ true }

--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import { Container, Stack, Typography } from "@mui/material";
 import { FunctionComponent, useState } from "react";
 import { ProfileHeader, ProfileModal } from "@newm-web/components";
@@ -15,6 +16,9 @@ interface ArtistProps {
 const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
   const { isLoading, data: artist, error } = useGetArtistQuery(params.artistId);
   const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
+
+  const artistBannerUrl = artist?.bannerUrl;
+  const profileHeaderLayout = artistBannerUrl ? "overlay" : "inline";
 
   const socials = {
     instagramUrl: artist?.instagramUrl || "",
@@ -33,12 +37,17 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
   return (
     <>
       <Stack direction="column">
-        <BannerImage imageUrl={ artist?.bannerUrl } isLoading={ isLoading } />
+        { artistBannerUrl && (
+          <BannerImage imageUrl={ artistBannerUrl } isLoading={ isLoading } />
+        ) }
 
-        <Container sx={ { flexGrow: 1 } }>
+        <Container
+          sx={ { flexGrow: 1, marginTop: artistBannerUrl ? 0 : "3.5rem" } }
+        >
           <ProfileHeader
             isLoading={ isLoading }
             isVerified={ true }
+            layout={ profileHeaderLayout }
             location={ artist?.location }
             name={ artist?.name }
             pictureUrl={ artist?.pictureUrl }

--- a/apps/marketplace/src/app/artist/[artistId]/page.tsx
+++ b/apps/marketplace/src/app/artist/[artistId]/page.tsx
@@ -42,7 +42,7 @@ const Artist: FunctionComponent<ArtistProps> = ({ params }) => {
           <BannerImage imageUrl={ artistBannerUrl } isLoading={ isLoading } />
         ) }
 
-        <Container sx={ { flexGrow: 1, marginTop: showBannerArea ? 0 : "3.5rem" } }>
+        <Container sx={ { flexGrow: 1, marginTop: showBannerArea ? 0 : 7 } }>
           <ProfileHeader
             isLoading={ isLoading }
             isVerified={ true }

--- a/packages/components/src/lib/ProfileHeader.tsx
+++ b/packages/components/src/lib/ProfileHeader.tsx
@@ -9,6 +9,7 @@ import ProfileHeaderSkeleton from "./skeletons/ProfileHeaderSkeleton";
 interface ProfileHeaderProps {
   readonly isLoading?: boolean;
   readonly isVerified?: boolean;
+  readonly layout?: "overlay" | "inline";
   readonly location?: string;
   readonly name?: string;
   readonly onClickAbout: VoidFunction;
@@ -24,8 +25,11 @@ const ProfileHeader: FunctionComponent<ProfileHeaderProps> = ({
   socials,
   isLoading,
   isVerified = false,
+  layout = "overlay",
 }) => {
   const theme = useTheme();
+
+  const isOverlay = layout === "overlay";
 
   const isBelowMdBreakpoint = useBetterMediaQuery(
     `(max-width: ${theme.breakpoints.values.md}px)`
@@ -40,7 +44,7 @@ const ProfileHeader: FunctionComponent<ProfileHeaderProps> = ({
       alignItems={ ["center", "center", "flex-start"] }
       direction={ ["column", "column", "row"] }
       justifyContent="space-between"
-      mt={ [-12.5, -12.5, 0] }
+      mt={ isOverlay ? [-12.5, -12.5, 0] : 0 }
       px={ 2.5 }
     >
       <Stack
@@ -110,7 +114,7 @@ const ProfileHeader: FunctionComponent<ProfileHeaderProps> = ({
         </Stack>
       </Stack>
 
-      <Box mt={ 2.5 }>
+      <Box mt={ isOverlay ? 2.5 : isBelowMdBreakpoint ? 3 : -2 }>
         <Socials
           instagramUrl={ socials.instagramUrl }
           itunesUrl={ socials.itunesUrl }


### PR DESCRIPTION
# Pull Request — Issue [MRKT-209](https://projectnewm.atlassian.net/browse/MRKT-209)

## Overview

> This PR fixes the artist page layout when no banner image is available. It conditionally renders the banner, ensures the banner skeleton shows while loading, switches `ProfileHeader` to an inline layout when no banner (or not loading), and adjusts margins to remove the black gap while preserving the overlay layout when a banner exists.

---

## Files Summary

> **Total Changes:** 2 files

<details>
<summary>Added (0)</summary>

- None

</details>

<details>
<summary>Modified (2)</summary>

- `apps/marketplace/src/app/artist/[artistId]/page.tsx`
  - Show banner area while loading or when a URL exists: `const showBannerArea = isLoading || !!artistBannerUrl`.
  - Render `BannerImage` when `showBannerArea` is true to display the skeleton during loading.
  - Derive `profileHeaderLayout` from `showBannerArea` (overlay when true, inline otherwise).
  - Apply `Container` `marginTop` based on `showBannerArea` to remove the black gap.
- `packages/components/src/lib/ProfileHeader.tsx`
  - Add optional `layout?: "overlay" | "inline"` prop (default: `"overlay"`).
  - Use `isOverlay` to adjust top margins to match layout.
  - Tweak Socials container margin to account for layout and breakpoint.

</details>

<details>
<summary>Deleted (0)</summary>

- None

</details>

---

## Impact

- Removes the unwanted black gap on artist pages without a banner.
- Preserves existing overlay appearance for artists with banners.
- Shows banner skeleton during loading for a smoother perceived load.
- Backward compatible: `ProfileHeader` defaults to `layout="overlay"`.

---

## Testing

- Manual QA in Marketplace:
  - With banner: header overlays banner; spacing unchanged.
  - Without banner: header inline; no black gap; spacing correct across breakpoints.
  - While loading: banner skeleton renders; layout uses overlay until data resolves.
- Verified responsive behavior near the `md` breakpoint.

---

## Related Issues

- Closes [MRKT-209](https://projectnewm.atlassian.net/browse/MRKT-209)

---

## Dependencies

- No new or updated dependencies.

---

## Demo


https://github.com/user-attachments/assets/eb43e347-e729-4e52-bbca-82953d190757


---

## Additional Notes

- The `layout` prop on `ProfileHeader` supports future non-overlay contexts.
- **⚠️ On Mobile (artist with no banner): There is a bit of a gap between the profile header and the search bar. Doesn't look bad, but its a preference thing. We could use the `useBetterMediaQuery` hook to conditionally apply a different margin-top. TO BE CHECKED**


[MRKT-209]: https://projectnewm.atlassian.net/browse/MRKT-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MRKT-209]: https://projectnewm.atlassian.net/browse/MRKT-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ