### PR TITLE
[STUD-376][fix/enhancement]: Update format for displayed percentage of total minted stream tokens to better represent actual total.

### DIFF
--- a/apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx
+++ b/apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx
@@ -15,9 +15,8 @@ import {
 import theme from "@newm-web/theme";
 import {
   Currency,
-  calculateOwnershipPerecentage,
   formatNewmAmount,
-  formatPercentageAdaptive,
+  formatOwnershipPercentage,
   formatUsdAmount,
   useWindowDimensions,
 } from "@newm-web/utils";
@@ -78,9 +77,9 @@ export const CreateSale = () => {
   }, [getUserWalletSongs, songId, wallet]);
 
   const streamTokensInWallet = currentSong?.token_amount || 0;
-  const streamTokensPercentage = formatPercentageAdaptive(
-    calculateOwnershipPerecentage(streamTokensInWallet)
-  );
+  const streamTokensPercentage =
+    formatOwnershipPercentage(streamTokensInWallet);
+
   const formattedStreamTokensInWallet = currency(streamTokensInWallet, {
     precision: 0,
     symbol: "",
@@ -132,7 +131,7 @@ export const CreateSale = () => {
           fontWeight={ 500 }
           variant="subtitle1"
         >
-          { `This accounts for ${streamTokensPercentage}% of this track's total minted stream tokens.` }
+          { `This accounts for ${streamTokensPercentage} of this track's total minted stream tokens.` }
         </Typography>
       </Alert>
 

--- a/packages/utils/jest.config.ts
+++ b/packages/utils/jest.config.ts
@@ -8,4 +8,5 @@ export default {
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
   coverageDirectory: "../../coverage/packages/utils",
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests"],
 };

--- a/packages/utils/src/lib/sales.ts
+++ b/packages/utils/src/lib/sales.ts
@@ -81,3 +81,48 @@ export const formatPercentageAdaptive = (percentage: number) => {
 
   return parseFloat(formattedPercentage);
 };
+
+/**
+ * * Formats ownership percentage for display.
+ *
+ * * Rules:
+ * * - Shows "100%" ONLY when the owned token count exactly equals the total minted supply.
+ * * - Whole-number percentages (other than 100) are displayed without decimals.
+ * * - Fractional percentages are displayed with up to 6 decimal places,
+ * *   and trimming trailing zeros to avoid misleading precision.
+ *
+ * * This prevents cases where values like 99.999901% are incorrectly shown as "100%".
+ *
+ * @param tokens - Number of tokens owned
+ * @param totalTokens - Total minted stream tokens (default: FULL_OWNERSHIP_STREAM_TOKENS)
+ * @returns Formatted percentage string (e.g. "50%", "49.999223%", "99.999901%")
+ */
+export const formatOwnershipPercentage = (
+  tokens: number,
+  totalTokens: number = FULL_OWNERSHIP_STREAM_TOKENS
+): string => {
+  if (!Number.isFinite(tokens) || tokens <= 0) {
+    return "0%";
+  }
+
+  if (tokens === totalTokens) {
+    return "100%";
+  }
+
+  const percentage =
+    totalTokens === FULL_OWNERSHIP_STREAM_TOKENS
+      ? calculateOwnershipPerecentage(tokens)
+      : (tokens / totalTokens) * 100;
+
+  // * Whole numbers (excluding 100, which is already handled)
+  if (Number.isInteger(percentage)) {
+    return `${percentage}%`;
+  }
+
+  // * Fractional values:
+  // * - Use fixed precision to avoid floating-point artifacts
+  // * - Trim trailing zeros for clean display
+  const formatted = percentage.toFixed(6).replace(/\.?0+$/, "");
+
+  return `${formatted}%`;
+};

--- a/packages/utils/src/lib/test/sales.test.ts
+++ b/packages/utils/src/lib/test/sales.test.ts
@@ -1,0 +1,196 @@
+import { formatOwnershipPercentage } from "../sales";
+
+describe("#formatOwnershipPercentage utility", () => {
+  describe("exactly 100% ownership", () => {
+    it("should return '100%' when tokens exactly equal total tokens", () => {
+      expect(formatOwnershipPercentage(100000000)).toBe("100%");
+      expect(formatOwnershipPercentage(100000000, 100000000)).toBe("100%");
+    });
+
+    it("should return '100%' with custom total tokens", () => {
+      expect(formatOwnershipPercentage(1000, 1000)).toBe("100%");
+      expect(formatOwnershipPercentage(50, 50)).toBe("100%");
+    });
+  });
+
+  describe("whole number percentages", () => {
+    it("should return whole numbers without decimals", () => {
+      expect(formatOwnershipPercentage(50000000)).toBe("50%");
+      expect(formatOwnershipPercentage(1000000)).toBe("1%");
+      expect(formatOwnershipPercentage(25000000)).toBe("25%");
+      expect(formatOwnershipPercentage(75000000)).toBe("75%");
+    });
+
+    it("should handle 0% case", () => {
+      expect(formatOwnershipPercentage(0)).toBe("0%");
+    });
+
+    it("should handle whole numbers with custom total tokens", () => {
+      expect(formatOwnershipPercentage(50, 100)).toBe("50%");
+      expect(formatOwnershipPercentage(1, 10)).toBe("10%");
+      expect(formatOwnershipPercentage(3, 10)).toBe("30%");
+    });
+  });
+
+  describe("fractional percentages", () => {
+    it("should show fractional percentages with appropriate decimals", () => {
+      // 49.999223% from the image example
+      expect(formatOwnershipPercentage(49999223)).toBe("49.999223%");
+
+      // 99.999901% - close to 100% but not exactly
+      expect(formatOwnershipPercentage(99999901)).toBe("99.999901%");
+
+      // 99.999999% - very close to 100%
+      expect(formatOwnershipPercentage(99999999)).toBe("99.999999%");
+    });
+
+    it("should trim trailing zeros", () => {
+      // 50.5% should show as "50.5%" not "50.500000%"
+      expect(formatOwnershipPercentage(50500000)).toBe("50.5%");
+
+      // 25.25% should show as "25.25%" not "25.250000%"
+      expect(formatOwnershipPercentage(25250000)).toBe("25.25%");
+
+      // 10.1% should show as "10.1%" not "10.100000%"
+      expect(formatOwnershipPercentage(10100000)).toBe("10.1%");
+    });
+
+    // * Correct today
+    // ! But this assumes no minimum decimal padding, which is fine,
+    // * we must be aware of this design decision, not an AC requirement.
+    // ! If product later says 'always show at least 2 decimals', this test will break.
+    it("should preserve significant decimal places", () => {
+      // 0.5% should show decimals
+      expect(formatOwnershipPercentage(500000)).toBe("0.5%");
+
+      // 0.1% should show decimals
+      expect(formatOwnershipPercentage(100000)).toBe("0.1%");
+
+      // 0.01% should show decimals
+      expect(formatOwnershipPercentage(10000)).toBe("0.01%");
+    });
+
+    it("should handle very small percentages", () => {
+      // 0.000001% (1 token out of 100M)
+      expect(formatOwnershipPercentage(1)).toBe("0.000001%");
+
+      // 0.00001% (10 tokens)
+      expect(formatOwnershipPercentage(10)).toBe("0.00001%");
+
+      // 0.0001% (100 tokens)
+      expect(formatOwnershipPercentage(100)).toBe("0.0001%");
+    });
+
+    it("should handle percentages with many decimal places", () => {
+      // 33.333333% (1/3 of total)
+      expect(formatOwnershipPercentage(33333333)).toBe("33.333333%");
+
+      // 66.666666% (2/3 of total)
+      expect(formatOwnershipPercentage(66666666)).toBe("66.666666%");
+    });
+  });
+
+  describe("edge cases near 100%", () => {
+    it("should not round 99.999901% to 100%", () => {
+      const result = formatOwnershipPercentage(99999901);
+      expect(result).toBe("99.999901%");
+      expect(result).not.toBe("100%");
+    });
+
+    it("should not round 99.999999% to 100%", () => {
+      const result = formatOwnershipPercentage(99999999);
+      expect(result).toBe("99.999999%");
+      expect(result).not.toBe("100%");
+    });
+
+    it("should handle 99.9% correctly", () => {
+      expect(formatOwnershipPercentage(99900000)).toBe("99.9%");
+    });
+
+    it("should handle 99.99% correctly", () => {
+      expect(formatOwnershipPercentage(99990000)).toBe("99.99%");
+    });
+
+    it("should handle 99.999% correctly", () => {
+      expect(formatOwnershipPercentage(99999000)).toBe("99.999%");
+    });
+  });
+
+  describe("edge cases near 0%", () => {
+    it("should handle single token", () => {
+      expect(formatOwnershipPercentage(1)).toBe("0.000001%");
+    });
+
+    it("should handle very small amounts", () => {
+      expect(formatOwnershipPercentage(77)).toBe("0.000077%");
+      expect(formatOwnershipPercentage(123)).toBe("0.000123%");
+    });
+  });
+
+  describe("custom total tokens", () => {
+    it("should work with custom total token values", () => {
+      // 50% of 1000
+      expect(formatOwnershipPercentage(500, 1000)).toBe("50%");
+
+      // 33.333333% of 3
+      expect(formatOwnershipPercentage(1, 3)).toBe("33.333333%");
+
+      // 66.666666% of 3
+      // * NOTE:
+      // * This test intentionally asserts rounding (not truncation) to 6 decimal places.
+      // * The formatter uses `toFixed(6)`, which rounds the final digit.
+      // * Truncation would also be Jira compliant, but rounding was chosen to preserve
+      // * numerical accuracy and consistency across fractional ownership displays.
+      // ! If later we 'truncate' to 6 decimals, this test will break.
+      expect(formatOwnershipPercentage(2, 3)).toBe("66.666667%");
+
+      // 25.5% of 100
+      expect(formatOwnershipPercentage(25.5, 100)).toBe("25.5%");
+    });
+
+    it("should handle fractional tokens with custom total", () => {
+      // 1.5 out of 10 = 15%
+      expect(formatOwnershipPercentage(1.5, 10)).toBe("15%");
+
+      // 0.1 out of 1 = 10%
+      expect(formatOwnershipPercentage(0.1, 1)).toBe("10%");
+    });
+  });
+
+  describe("floating point precision handling", () => {
+    it("should handle floating point arithmetic correctly", () => {
+      // Test that floating point errors don't cause issues
+      const result1 = formatOwnershipPercentage(33333333);
+      expect(result1).toMatch(/^33\.33333\d*%$/);
+
+      const result2 = formatOwnershipPercentage(66666666);
+      expect(result2).toMatch(/^66\.66666\d*%$/);
+    });
+
+    it("should not show misleading precision beyond 6 decimals", () => {
+      // Even if calculation has more precision, should cap at 6 decimals
+      const result = formatOwnershipPercentage(1234567);
+      // Should be 1.234567% (6 decimals max)
+      expect(result).toBe("1.234567%");
+    });
+  });
+
+  describe("invalid or non-positive token values", () => {
+    it("should return 0% when tokens are 0", () => {
+      expect(formatOwnershipPercentage(0)).toBe("0%");
+    });
+
+    it("should return 0% when tokens are negative", () => {
+      expect(formatOwnershipPercentage(-1)).toBe("0%");
+      expect(formatOwnershipPercentage(-100)).toBe("0%");
+    });
+
+    it("should return 0% when tokens are negative with custom total", () => {
+      expect(formatOwnershipPercentage(-10, 100)).toBe("0%");
+    });
+
+    it("should return 0% when tokens is NaN", () => {
+      expect(formatOwnershipPercentage(NaN)).toBe("0%");
+    });
+  });
+});

--- a/packages/utils/src/setupTests.js
+++ b/packages/utils/src/setupTests.js
@@ -1,0 +1,10 @@
+jest.mock("@newm-web/env", () => ({
+  APPLE_CLIENT_ID: "EXAMPLE_ID",
+  GOOGLE_CLIENT_ID: "EXAMPLE_ID",
+  GA_STUDIO_ID: "EXAMPLE_ID",
+  NX_CLOUD_ACCESS_TOKEN: "EXAMPLE_TOKEN",
+  NODE_ENV: "test",
+  ENV: "test",
+  isProd: false,
+  RECAPTCHA_SITE_KEY: "EXAMPLE_RECAPTCHA_KEY"
+}));


### PR DESCRIPTION
# Pull Request — Issue #[STUD-376](https://projectnewm.atlassian.net/browse/STUD-376)

## Overview

> Update how we display a user's percentage of total minted stream tokens in Studio so values near 100% are not shown as '100%' unless the user truly owns the full supply. This introduces a purpose-built formatter in utils and switches `CreateSale` to use it.

---

## Files Summary

> **Total Changes:** 5 files  
> Added: 2 • Modified: 3 • Deleted: 0

<details>
<summary>Added (2)</summary>

- `packages/utils/src/lib/test/sales.test.ts`  
  - Jest test suite for the new `formatOwnershipPercentage` utility, covering exact 100%, whole numbers, fractional values (up to 6 decimals), very small percentages, edge cases near 0%/100%, custom totals, and invalid inputs.
- `packages/utils/src/setupTests.js`  
  - Jest setup to mock `@newm-web/env`, preventing `import.meta`/env access issues when running utils tests.

</details>

<details>
<summary>Modified (3)</summary>

- `apps/studio/src/pages/home/library/MarketplaceTab/CreateSale.tsx`  
  - Replace `calculateOwnershipPerecentage(...)` + `formatPercentageAdaptive(...)` with `formatOwnershipPercentage(...)` for the alert that states how much of the total minted stream tokens the user holds.
- `packages/utils/src/lib/sales.ts`  
  - Add `formatOwnershipPercentage(tokens, totalTokens = FULL_OWNERSHIP_STREAM_TOKENS): string` with explicit rules: exact 100% only on equality; whole numbers without decimals; fractional values rounded to 6 decimals with trailing zeros trimmed; non‑positive/invalid inputs → `"0%"`.
- `packages/utils/jest.config.ts`  
  - Load `setupFilesAfterEnv` to initialize the env mock for utils tests.

</details>

<details>
<summary>Deleted (0)</summary>

- None

</details>

---

## Impact

- Create Sale's alert now shows an accurate, non-misleading ownership percentage across all ranges, especially for values close to 100% and very small values.
- Centralizes ownership percentage formatting logic in utils for consistency and future reuse.

---

## Testing

- Unit tests: comprehensive coverage added in `packages/utils/src/lib/test/sales.test.ts`.
  - Run with: `npx nx test utils --testPathPattern=sales.test`.

### `#formatOwnershipPercentage` utility - Example Inputs & Outputs

_Assuming a total supply of **100,000,000 stream tokens**._

| Tokens Owned | Calculated % | Formatted Output | Notes |
|-------------|--------------|------------------|------|
| `100,000,000` | `100%` | `100%` | Exact full ownership |
| `99,999,999` | `99.999999%` | `99.999999%` | Near-100%, not rounded |
| `99,999,901` | `99.999901%` | `99.999901%` | Prevents misleading `100%` |
| `75,000,000` | `75%` | `75%` | Whole number percentage |
| `50,000,000` | `50%` | `50%` | Whole number percentage |
| `49,999,223` | `49.999223%` | `49.999223%` | Fractional value (image example) |
| `25,250,000` | `25.25%` | `25.25%` | Trailing zeros trimmed |
| `10,100,000` | `10.1%` | `10.1%` | Minimal decimals preserved |
| `1,000,000` | `1%` | `1%` | Small whole number |
| `500,000` | `0.5%` | `0.5%` | Fractional < 1% |
| `10,000` | `0.01%` | `0.01%` | Very small percentage |
| `1` | `0.000001%` | `0.000001%` | Smallest non-zero value |
| `0` | `0%` | `0%` | Non-positive input guard |
| `-100` | `0%` | `0%` | Defensive handling |

#### Formatting rules

- `100%` is shown **only** when owned tokens exactly equal total minted supply  
- Whole numbers are displayed **without decimals**  
- Fractional values show **enough precision (min 2, max 6 decimals)** to avoid misleading rounding  
- Trailing zeros are trimmed  
- Non-positive values safely return `0%`

#### Testing notes

- Manual verification is difficult here due to the need for specific token ownership states.
- Coverage is provided via unit tests and a documented input/output table to make behavior explicit and easy to review.

---

## Related Issues

- Closes #[STUD-376](https://projectnewm.atlassian.net/browse/STUD-376)

---

## Dependencies

- No new or updated dependencies.

---

## Additional Notes

- Follow-up (StartSaleModal): Should we consider using `formatOwnershipPercentage(...)` for consistency in places where we currently rely on `formatPercentageAdaptive(...)`?
  - References:
    - `apps/studio/src/pages/home/library/MarketplaceTab/StartSaleModal.tsx:111`
    - `apps/studio/src/pages/home/library/MarketplaceTab/StartSaleModal.tsx:126`


[STUD-376]: https://projectnewm.atlassian.net/browse/STUD-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-376]: https://projectnewm.atlassian.net/browse/STUD-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ