### PR TITLE
[MRKT-232][enhancement]: marketplace/not-found — add 'originAppName' prop to contextualize 404 redirect.

### DIFF
--- a/apps/marketplace/src/app/not-found.tsx
+++ b/apps/marketplace/src/app/not-found.tsx
@@ -9,6 +9,7 @@ const NotFound: FunctionComponent = () => {
   return (
     <PageNotFound
       layout="topbar"
+      originAppName="Marketplace"
       redirectUrl="/"
       onNavigate={ (url) => router.push(url) }
     />


### PR DESCRIPTION
# Pull Request - Issue #[MRKT-232](https://projectnewm.atlassian.net/browse/MRKT-232)

## Overview

> This PR adds an `originAppName` prop to the `<PageNotFound />` component within the Marketplace app.  
> This provides better contextualization when rendering a 404 screen and allows downstream navigation or UI logic to differentiate where the error originated.

---

## Files Summary

> **Total Changes:** 1 file modified

<details>
<summary> Modified (1)</summary>

- **`apps/marketplace/src/app/not-found.tsx`**  
  — Added `originAppName="Marketplace"` prop to `PageNotFound` call to ensure redirects/navigation can be contextualized to Marketplace.  
</details>

---

## Impact

- Improves UX context when a 404 occurs coming from Marketplace.
- Enables downstream usage of origin metadata (navigation handlers, shared not-found screen, etc.).
- No breaking changes expected, as it only adds props in Marketplace instantiation.
- No styling or visual regressions.

---

## Testing

- Manually tested navigating to an invalid Marketplace route and verifying redirect behavior.
- Confirmed the `originAppName` propagates correctly to the shared component.
- No unit tests were added (component behavior unchanged functionally beyond prop pass-through).

---

## Demo

> Example: Marketplace 404 now shows contextual redirect behavior.

<img width="1457" height="735" alt="Screenshot 2026-01-09 170019" src="https://github.com/user-attachments/assets/4de93831-7c5f-4468-be87-67316e874ad5" />

---

## Related Issues

- Closes #[MRKT-232](https://projectnewm.atlassian.net/browse/MRKT-232)

---

## Dependencies

- No new dependencies.

---

[MRKT-232]: https://projectnewm.atlassian.net/browse/MRKT-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MRKT-232]: https://projectnewm.atlassian.net/browse/MRKT-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ