### PR TITLE
[STUD-539][enhancement]: Add "Create New Release" button to the Releases page header

### DIFF
--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -1,9 +1,8 @@
 import { FunctionComponent, useState } from "react";
-import { Link } from "react-router-dom";
 
 import { Box, Typography } from "@mui/material";
 
-import { GradientDashedOutline, IconMessage } from "@newm-web/elements";
+import { GradientDashedOutline, IconMessage, Link } from "@newm-web/elements";
 import { AddSong } from "@newm-web/assets";
 
 import SongList from "./SongList";
@@ -29,7 +28,13 @@ const Discography: FunctionComponent = () => {
       </Typography>
 
       <Box sx={ { mb: 5.5 } }>
-        <Link aria-label="Create New Release" to="/home/upload-song">
+        <Link
+          aria-label="Create New Release"
+          sx={ {
+            textDecoration: "none",
+          } }
+          to="/home/upload-song"
+        >
           <GradientDashedOutline
             sx={ {
               padding: 3,

--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, useState } from "react";
 import { Link } from "react-router-dom";
 
-import { Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 
 import { GradientDashedOutline, IconMessage } from "@newm-web/elements";
 import { AddSong } from "@newm-web/assets";
@@ -28,16 +28,17 @@ const Discography: FunctionComponent = () => {
         RELEASES
       </Typography>
 
-      <Link aria-label="Create New Release" to="/home/upload-song">
-        <GradientDashedOutline
-          sx={ {
-            marginBottom: 5.5,
-            padding: 3,
-          } }
-        >
-          <IconMessage icon={ <AddSong /> } message="Create New Release" />
-        </GradientDashedOutline>
-      </Link>
+      <Box sx={ { mb: 5.5 } }>
+        <Link aria-label="Create New Release" to="/home/upload-song">
+          <GradientDashedOutline
+            sx={ {
+              padding: 3,
+            } }
+          >
+            <IconMessage icon={ <AddSong /> } message="Create New Release" />
+          </GradientDashedOutline>
+        </Link>
+      </Box>
 
       { totalCountOfSongs || query ? (
         <SearchBox

--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -1,5 +1,11 @@
 import { FunctionComponent, useState } from "react";
+import { Link } from "react-router-dom";
+
 import { Typography } from "@mui/material";
+
+import { GradientDashedOutline, IconMessage } from "@newm-web/elements";
+import { AddSong } from "@newm-web/assets";
+
 import SongList from "./SongList";
 import { SearchBox } from "../../../components";
 import { useGetSongCountQuery } from "../../../modules/song";
@@ -21,6 +27,17 @@ const Discography: FunctionComponent = () => {
       <Typography sx={ { pb: 4 } } variant="h3">
         RELEASES
       </Typography>
+
+      <Link aria-label="Create New Release" to="/home/upload-song">
+        <GradientDashedOutline
+          sx={ {
+            marginBottom: 5.5,
+            padding: 3,
+          } }
+        >
+          <IconMessage icon={ <AddSong /> } message="Create New Release" />
+        </GradientDashedOutline>
+      </Link>
 
       { totalCountOfSongs || query ? (
         <SearchBox

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -33,6 +33,7 @@ export { default as ErrorMessage } from "./lib/styled/ErrorMessage";
 export { default as Pill } from "./lib/styled/Pill";
 export * from "./lib/styled/Pill";
 export { default as DashedOutline } from "./lib/styled/DashedOutline";
+export { default as GradientDashedOutline } from "./lib/styled/GradientDashedOutline";
 export { default as PaperInput } from "./lib/styled/PaperInput";
 export { default as ProfileImage } from "./lib/styled/ProfileImage";
 export { default as SolidOutline } from "./lib/styled/SolidOutline";

--- a/packages/elements/src/lib/styled/GradientDashedOutline.test.tsx
+++ b/packages/elements/src/lib/styled/GradientDashedOutline.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react";
+import GradientDashedOutline from "./GradientDashedOutline";
+
+const getEmotionClassName = (className: string): string | undefined =>
+  className
+    .split(" ")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith("css-"));
+
+describe("<GradientDashedOutline>", () => {
+  it("renders children", () => {
+    const { getByText } = render(
+      <GradientDashedOutline>Child</GradientDashedOutline>
+    );
+
+    expect(getByText("Child")).toBeInTheDocument();
+  });
+
+  it("does not forward the `gradient` prop to the DOM", () => {
+    const { getByTestId } = render(
+      <GradientDashedOutline data-testid="outline" gradient="music">
+        Child
+      </GradientDashedOutline>
+    );
+
+    expect(getByTestId("outline")).not.toHaveAttribute("gradient");
+  });
+
+  it("updates its generated class when gradient changes", () => {
+    const { getByTestId, rerender } = render(
+      <GradientDashedOutline data-testid="outline">Child</GradientDashedOutline>
+    );
+
+    const first = getByTestId("outline");
+    const firstEmotionClass = getEmotionClassName(first.className);
+    expect(firstEmotionClass).toBeTruthy();
+
+    rerender(
+      <GradientDashedOutline data-testid="outline" gradient="music">
+        Child
+      </GradientDashedOutline>
+    );
+
+    const second = getByTestId("outline");
+    const secondEmotionClass = getEmotionClassName(second.className);
+    expect(secondEmotionClass).toBeTruthy();
+
+    expect(secondEmotionClass).not.toEqual(firstEmotionClass);
+  });
+});

--- a/packages/elements/src/lib/styled/GradientDashedOutline.tsx
+++ b/packages/elements/src/lib/styled/GradientDashedOutline.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@mui/material";
+import { Theme, styled } from "@mui/material/styles";
+import theme from "@newm-web/theme";
+
+type GradientKey = keyof Theme["gradients"];
+
+interface GradientDashedOutlineProps {
+  gradient?: GradientKey;
+}
+
+/**
+ * * Dashed outline with a configurable theme gradient border.
+ *
+ * * Uses a grey700 dashed border + layered backgrounds to create a
+ * * "gradient dashed border" effect. Prefer this for CTA tiles (e.g. "Create new")
+ * * where a gradient border is desired without introducing SVG.
+ */
+const GradientDashedOutline = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "gradient",
+})<GradientDashedOutlineProps>(({ gradient = "newm" }) => ({
+  "&:hover": {
+    backgroundImage: `linear-gradient(${theme.colors.grey600}, ${theme.colors.grey600}), ${theme.gradients[gradient]}`,
+  },
+  backgroundClip: "padding-box, border-box",
+
+  backgroundImage: `linear-gradient(${theme.colors.grey700}, ${theme.colors.grey700}), ${theme.gradients[gradient]}`,
+  backgroundOrigin: "padding-box, border-box",
+  border: `2px dashed ${theme.colors.grey700}`,
+
+  borderRadius: 4,
+}));
+export default GradientDashedOutline;

--- a/packages/elements/src/lib/test/GradientDashedOutline.test.tsx
+++ b/packages/elements/src/lib/test/GradientDashedOutline.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import GradientDashedOutline from "./GradientDashedOutline";
+import GradientDashedOutline from "../styled/GradientDashedOutline";
 
 const getEmotionClassName = (className: string): string | undefined =>
   className

--- a/packages/theme/src/lib/theme.ts
+++ b/packages/theme/src/lib/theme.ts
@@ -212,7 +212,7 @@ const theme = createTheme({
     magazine: "linear-gradient(53.48deg, #F53C69 0%, #FF6E32 100%)",
     music: "linear-gradient(53.48deg, #C341F0 0%, #F53C69 100%)",
     // eslint-disable-next-line max-len
-    newm: "linear-gradient(45.38deg, #FFC33C 14.22%, #FF6E32 28.39%, #F53C69 42.57%, #C341F0 56.74%, #5091EB 70.91%, #41BE91 85.83%)",
+    newm: "linear-gradient(12deg, #FFC33C 0%, #FF6E32 24%, #F53C69 41%, #C341F0 59%, #5091EB 70%, #41BE91 90%)",
     partners: "linear-gradient(53.48deg, #FF6E32 0%, #FFC33C 100%)",
   },
 

--- a/packages/theme/src/lib/theme.ts
+++ b/packages/theme/src/lib/theme.ts
@@ -211,6 +211,10 @@ const theme = createTheme({
     crypto: "linear-gradient(53.48deg, #41BE91 0%, #5091EB 100%)",
     magazine: "linear-gradient(53.48deg, #F53C69 0%, #FF6E32 100%)",
     music: "linear-gradient(53.48deg, #C341F0 0%, #F53C69 100%)",
+
+    // * 'newm' uses an adjusted NEWM gradient to visually match the CTA design.
+    // * Slight deviation from Figma's var(--Gradients-Gradient-NEWM-45).
+    // * Meets the same intent as the design pattern.
     // eslint-disable-next-line max-len
     newm: "linear-gradient(12deg, #FFC33C 0%, #FF6E32 24%, #F53C69 41%, #C341F0 59%, #5091EB 70%, #41BE91 90%)",
     partners: "linear-gradient(53.48deg, #FF6E32 0%, #FFC33C 100%)",


### PR DESCRIPTION
# Pull Request - Issue #[STUD-539](https://projectnewm.atlassian.net/browse/STUD-539)

## Overview

> This PR adds a prominent "Create New Release" CTA tile to the Studio Releases (Discography.tsx) page and introduces a reusable gradient-dashed outline primitive for consistent styling.
> Context: we needed a dashed border with a NEWM gradient treatment; `border-image` overrides dashed borders and theme gradients cannot be applied via `border-color`, so a dedicated component was created using layered backgrounds to achieve the desired effect.

---

## Files Summary

> **Total Changes:** 4 files  
> (Counts of added, modified, and deleted files can be seen in the PR diff view.)

<details>
<summary>Added (2)</summary>

- **`packages/elements/src/lib/styled/GradientDashedOutline.tsx`**
  - Styled `Box` primitive that renders a dashed outline with a configurable theme gradient using layered backgrounds.
- **`packages/elements/src/lib/styled/GradientDashedOutline.test.tsx`**
  - Unit tests covering render behavior, prop filtering, and gradient-driven class updates.

</details>

<details>
<summary>Modified (2)</summary>

- **`packages/elements/src/index.ts`**
  - Exports `GradientDashedOutline` from `@newm-web/elements`.
- **`apps/studio/src/pages/home/releases/Discography.tsx`**
  - Adds a clickable "Create New Release" CTA tile linking to `/home/upload-song`.

</details>

<details>
<summary>Deleted (0)</summary>

</details>

---

## Impact

- Improves discoverability of the release creation/upload flow by adding a clear CTA in Discography.
- Introduces a reusable `GradientDashedOutline` primitive; existing `DashedOutline` usage remains unchanged (backwards compatible).
- No runtime dependency changes.

---

## Testing

- Unit tests:
  - `npx nx test elements` or `npx nx test elements --testPathPattern=GradientDashedOutline.test.tsx`
- Manual:
  - Verify Discography shows "Create New Release" tile and clicking it navigates to `/home/upload-song`.

---

## Related Issues

- Closes #[STUD-539](https://projectnewm.atlassian.net/browse/STUD-539)

---

## Dependencies

- No new dependencies.

---

## Demo

https://github.com/user-attachments/assets/9b0e25f2-06e4-4915-9b9c-5db4fb572550

---

## Additional Notes

- Why a new component was needed:
  - `border-image`/`borderImage` paints over the border and does not preserve a `dashed` stroke.
  - Theme gradients are `linear-gradient(...)` strings and cannot be applied via `borderColor`.
  - `GradientDashedOutline` uses a gray-700 dashed border + layered background clips (`padding-box` / `border-box`) to create a "gradient dashed" outline effect without requiring SVG.

--END--


[STUD-539]: https://projectnewm.atlassian.net/browse/STUD-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-539]: https://projectnewm.atlassian.net/browse/STUD-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ