### PR TITLE
[STUD-540][enhancement]: Update Releases table to include "Number of Tracks" and "Release Status" logic

### DIFF
--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -24,7 +24,7 @@ const Discography: FunctionComponent = () => {
 
       { totalCountOfSongs || query ? (
         <SearchBox
-          placeholder="Search songs"
+          placeholder="Search by release name"
           query={ query }
           onSearch={ handleSearch }
         />

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -423,6 +423,12 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
                 <TableCell sx={ { display: { lg: "table-cell", xs: "none" } } }>
                   { song.genres.join(", ") }
                 </TableCell>
+
+                <TableCell sx={ { display: { lg: "table-cell", xs: "none" } } }>
+                  { /* // ! Phase 1 → NO. OF TRACKS = 1; single-track until /v1/releases supports 'trackCount' */ }
+                  1
+                </TableCell>
+
                 <TableCell
                   sx={ {
                     display: { md: "table-cell", xs: "none" },

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -482,7 +482,7 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
         { totalCountOfSongs > songData.length && (
           <TablePagination
             cellStyles={ { paddingTop: "12px" } }
-            colSpan={ 5 }
+            colSpan={ 6 }
             handlePageChange={ handlePageChange }
             lastRowOnPage={ lastRowOnPage }
             numberOfRows={ totalCountOfSongs }

--- a/apps/studio/src/pages/home/releases/Table/TableHead.tsx
+++ b/apps/studio/src/pages/home/releases/Table/TableHead.tsx
@@ -5,12 +5,15 @@ const TableHead = () => {
   return (
     <MUITableHead>
       <TableRow>
-        <TableHeadCell>SONG NAME</TableHeadCell>
+        <TableHeadCell>RELEASE NAME</TableHeadCell>
         <TableHeadCell sx={ { display: { sm: "table-cell", xs: "none" } } }>
-          MINTING
+          RELEASE STATUS
         </TableHeadCell>
         <TableHeadCell sx={ { display: { lg: "table-cell", xs: "none" } } }>
           GENRE
+        </TableHeadCell>
+        <TableHeadCell sx={ { display: { lg: "table-cell", xs: "none" } } }>
+          NO. OF TRACKS
         </TableHeadCell>
         <TableHeadCell
           sx={ {


### PR DESCRIPTION
# Pull Request — Issue #[STUD-540](https://projectnewm.atlassian.net/browse/STUD-540)

## Overview

> This PR updates the Studio "Releases" table to:  
>
> - add a new "No. of Tracks" column (Phase 1: value defaults to `1` for all releases), and  
> - align table headers and copy with release terminology (e.g., "Release Name", "Release Status").  
> It also updates the search placeholder to "Search by release name" for clarity. These changes prepare the UI for upcoming multi‑track releases when the API exposes `trackCount`.

---

## Files Summary

> **Total Changes:** 3 files modified  
> No files added or deleted.

<details>
<summary>Modified (3)</summary>

- `apps/studio/src/pages/home/releases/Table/TableHead.tsx`  
  - Rename headers: "SONG NAME" → "RELEASE NAME"; "MINTING" → "RELEASE STATUS".  
  - Add "NO. OF TRACKS" header (visible on `lg` viewports).  
- `apps/studio/src/pages/home/releases/SongList.tsx`  
  - Render a new "No. of Tracks" column (visible on `lg`).  
  - Phase 1 behavior: display a static value of `1` until `/v1/releases` surfaces `trackCount`.  
  - Keeps pagination and row layout aligned with the new column.  
- `apps/studio/src/pages/home/releases/Discography.tsx`  
  - Update `SearchBox` placeholder: “Search by release name”.

</details>

---

## Impact

- UX: Adds a dedicated “No. of Tracks” column on large screens and clarifies table semantics with release‑focused labels.  
- Backward compatibility: No breaking changes. The column displays a static value (`1`) pending API support; does not affect data flows.  
- Performance/Deps: No performance impact. No dependency changes.

---

## Testing

- Manual QA  
  - Navigate to Studio → Home → Releases.  
  - Verify column headers match: Release Name, Release Status, Genre, No. of Tracks (lg‑only), Length.  
  - Confirm "No. of Tracks" shows `1` for all rows.  
  - Resize viewport: column visibility matches responsive rules (`lg` only for track count).  
  - Confirm the search placeholder reads “Search by release name” and filtering still functions.  
  - Sanity check clicking rows and action buttons still behaves as before.
- No new automated tests added; changes are presentational with a temporary static value.

---

## Related Issues

- Closes #[STUD-540](https://projectnewm.atlassian.net/browse/STUD-540)

---

## Dependencies

- No new dependencies.

---

## Demo

<img width="1357" height="626" alt="STUD-540" src="https://github.com/user-attachments/assets/c34809d2-57ca-4b89-b5e7-12f12e0b1561" />

---

## Additional Notes

- Phase 2/3: Replace the static `1` with API‑provided `trackCount` once exposed by `/v1/releases`.  
- Existing release status logic and tooltips remain unchanged; only the header label is updated to “Release Status”.

--END--


[STUD-540]: https://projectnewm.atlassian.net/browse/STUD-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-540]: https://projectnewm.atlassian.net/browse/STUD-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ