### PR TITLE
[STUD-542][enhancement]: Update tooltip for the disabled "delete song icon" in the Edit Song user flow

### DIFF
--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -4,6 +4,8 @@ import { isProd } from "@newm-web/env";
  * NEWM External Links and Support
  */
 export const NEWM_SUPPORT_EMAIL = "support@newm.io";
+export const NEWM_SUPPORT_LINK =
+  "https://projectnewm.atlassian.net/servicedesk/customer/portals";
 export const NEWM_CLICKUP_FORM_URL =
   "https://projectnewm.atlassian.net/servicedesk/customer/portal/1";
 export const NEWM_IO_URL = "https://newm.io/";

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -1,7 +1,7 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { Box, Stack, Tooltip, Typography } from "@mui/material";
-import { Button, ProfileImage, WizardForm } from "@newm-web/elements";
+import { Box, Stack, Typography } from "@mui/material";
+import { Button, ProfileImage, Tooltip, WizardForm } from "@newm-web/elements";
 import { FormikHelpers, FormikValues } from "formik";
 import { FunctionComponent, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
@@ -312,7 +312,7 @@ const EditSong: FunctionComponent = () => {
         { title && <Typography variant="h3">{ title.toUpperCase() }</Typography> }
 
         <>
-          <Tooltip title={ <ReleaseDeletionHelp /> } arrow>
+          <Tooltip title={ <ReleaseDeletionHelp /> }>
             <Stack ml="auto">
               <Button
                 color="white"

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -1,6 +1,6 @@
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import DeleteIcon from "@mui/icons-material/Delete";
-import { Box, Link, Stack, Tooltip, Typography } from "@mui/material";
+import { Box, Stack, Tooltip, Typography } from "@mui/material";
 import { Button, ProfileImage, WizardForm } from "@newm-web/elements";
 import { FormikHelpers, FormikValues } from "formik";
 import { FunctionComponent, useEffect, useState } from "react";
@@ -12,11 +12,8 @@ import { MintingStatus, PaymentType } from "@newm-web/types";
 import { useFlags } from "launchdarkly-react-client-sdk";
 import DeleteSongModal from "./DeleteSongModal";
 import { SongRouteParams } from "./types";
-import {
-  NEWM_SUPPORT_EMAIL,
-  commonYupValidation,
-  isSongEditable,
-} from "../../../common";
+import ReleaseDeletionHelp from "./ReleaseDeletionHelp";
+import { commonYupValidation, isSongEditable } from "../../../common";
 import {
   useGetGenresQuery,
   useGetISRCCountryCodesQuery,
@@ -315,20 +312,7 @@ const EditSong: FunctionComponent = () => {
         { title && <Typography variant="h3">{ title.toUpperCase() }</Typography> }
 
         <>
-          <Tooltip
-            title={
-              <span>
-                To delete a song for which minting and distribution is in
-                process or has completed, please send a deletion request email
-                to{ " " }
-                <Link href={ `mailto:${NEWM_SUPPORT_EMAIL}` }>
-                  { NEWM_SUPPORT_EMAIL }
-                </Link>
-                . Please note that artists not holding 100% of Stream Tokens for
-                a given track are unable to cease minting and distribution.
-              </span>
-            }
-          >
+          <Tooltip title={ <ReleaseDeletionHelp /> } arrow>
             <Stack ml="auto">
               <Button
                 color="white"

--- a/apps/studio/src/pages/home/releases/ReleaseDeletionHelp.tsx
+++ b/apps/studio/src/pages/home/releases/ReleaseDeletionHelp.tsx
@@ -1,0 +1,21 @@
+import { FunctionComponent } from "react";
+
+import { Link } from "@mui/material";
+
+import { NEWM_SUPPORT_LINK } from "../../../common";
+
+const ReleaseDeletionHelp: FunctionComponent = () => {
+  return (
+    <span>
+      To delete a release for which distribution is in process or has been
+      completed, please issue a Takedown Request via the&nbsp;
+      <Link href={ NEWM_SUPPORT_LINK } rel="noopener noreferrer" target="_blank">
+        NEWM Support Portal
+      </Link>
+      . Please note that we are unable to delete a release for which the
+      artist(s) does not hold 100% of the Stream Tokens.
+    </span>
+  );
+};
+
+export default ReleaseDeletionHelp;

--- a/apps/studio/src/pages/home/releases/ViewDetails.tsx
+++ b/apps/studio/src/pages/home/releases/ViewDetails.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, ReactNode, SyntheticEvent, useState } from "react";
-import { Box, Link, Stack, Tab, Tabs, Theme, Typography } from "@mui/material";
+import { Box, Stack, Tab, Tabs, Theme, Typography } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { useDispatch } from "react-redux";
@@ -13,7 +13,8 @@ import MintSong from "./MintSong";
 import SongInfo from "./SongInfo";
 import { SongRouteParams } from "./types";
 import { MarketplaceTab } from "./MarketplaceTab";
-import { NEWM_SUPPORT_EMAIL, isSongEditable } from "../../../common";
+import ReleaseDeletionHelp from "./ReleaseDeletionHelp";
+import { isSongEditable } from "../../../common";
 import { setToastMessage } from "../../../modules/ui";
 import {
   emptySong,
@@ -122,19 +123,7 @@ const ViewDetails: FunctionComponent = () => {
           width="90px"
         />
         { title && <Typography variant="h3">{ title.toUpperCase() }</Typography> }
-        <Tooltip
-          title={
-            <span>
-              To delete a song for which minting and distribution is in process
-              or has completed, please send a deletion request email to{ " " }
-              <Link href={ `mailto:${NEWM_SUPPORT_EMAIL}` }>
-                { NEWM_SUPPORT_EMAIL }
-              </Link>
-              . Please note that artists not holding 100% of Stream Tokens for a
-              given track are unable to cease minting and distribution.
-            </span>
-          }
-        >
+        <Tooltip title={ <ReleaseDeletionHelp /> } arrow>
           <Stack ml="auto">
             <Button
               color="white"

--- a/apps/studio/src/pages/home/releases/ViewDetails.tsx
+++ b/apps/studio/src/pages/home/releases/ViewDetails.tsx
@@ -123,7 +123,7 @@ const ViewDetails: FunctionComponent = () => {
           width="90px"
         />
         { title && <Typography variant="h3">{ title.toUpperCase() }</Typography> }
-        <Tooltip title={ <ReleaseDeletionHelp /> } arrow>
+        <Tooltip title={ <ReleaseDeletionHelp /> }>
           <Stack ml="auto">
             <Button
               color="white"


### PR DESCRIPTION
# Pull Request — Issue [STUD-542](https://projectnewm.atlassian.net/browse/STUD-542)

## Overview

This PR updates the tooltip behavior for the disabled Delete Song icon in the Edit Song and View Details flows. It introduces a reusable `ReleaseDeletionHelp` component that explains when a release cannot be deleted and directs users to submit a takedown request via the NEWM Support Portal. The change replaces prior hardcoded tooltip text with a centralized, consistently-styled component and adds a `NEWM_SUPPORT_LINK` constant for the portal URL.

---

## Files Summary

> **Total Changes:** 4 files

<details>
<summary>Added (1)</summary>

- `apps/studio/src/pages/home/releases/ReleaseDeletionHelp.tsx`
  - New component that renders explanatory copy for release deletion constraints and a link to the NEWM Support Portal.

</details>

<details>
<summary>Modified (3)</summary>

- `apps/studio/src/common/constants.ts`
  - Adds `NEWM_SUPPORT_LINK` pointing to the NEWM Support Portal for takedown requests.
- `apps/studio/src/pages/home/releases/EditSong.tsx`
  - Wraps the Delete button with a tooltip that renders `<ReleaseDeletionHelp />` when deletion is disabled.
  - Continues to use `getIsSongDeletable(mintingStatus)` to control disabled state.
- `apps/studio/src/pages/home/releases/ViewDetails.tsx`
  - Adds the same tooltip content (`<ReleaseDeletionHelp />`) around a disabled Delete icon in the read-only view.

</details>

<details>
<summary>Deleted (0)</summary>

- None

</details>

---

## Impact

- UX: Users now receive clear, actionable guidance when deletion is not permitted due to distribution/minting state, including a direct link to request a takedown.
- Consistency: Centralizes copy and behavior for deletion help across Edit and View Details pages via a shared component.
- No API changes; UI-only with a new constant for support link.

---

## Testing

Manual QA recommendations:

- Edit Song page
  - Open an ineligible song.
  - Verify the Delete icon is disabled and the tooltip displays the `ReleaseDeletionHelp` content with the Support Portal link opening in a new tab.
  - Open an eligible song (`getIsSongDeletable(mintingStatus)`) and confirm Delete remains enabled and flows as before.
- View Details page
  - Verify the Delete icon is disabled and shows the same tooltip content.
- Link
  - Confirm the Support Portal link uses `target="_blank"` and `rel="noopener noreferrer"` for safety.

---

## Related Issues

- Closes [STUD-542](https://projectnewm.atlassian.net/browse/STUD-542)

---

## Dependencies

- No new dependencies.

---

## Demo

<img width="322" height="244" alt="STUD-542" src="https://github.com/user-attachments/assets/a6db81ae-1f5b-4edf-9606-cedcdad27874" />

---

## Additional Notes

- `ReleaseDeletionHelp` is suitable both as tooltip content (e.g., `<Tooltip title={<ReleaseDeletionHelp />} />`) and as a standalone inline component wherever this guidance is needed.
- The component lives at `apps/studio/src/pages/home/releases/ReleaseDeletionHelp.tsx` and uses `NEWM_SUPPORT_LINK` from `apps/studio/src/common/constants.ts` (re-exported through the common barrel if applicable).
- This refactor replaces prior hardcoded tooltip strings to ensure consistent copy and easier future updates.

- **🚨 Note: `apps/studio/src/pages/home/releases/SongList.tsx` still uses `NEWM_SUPPORT_EMAIL` for a mailto action and tooltip guidance when minting errors occur. Consider switching to `NEWM_SUPPORT_LINK` to direct users to the Support Portal instead of opening an email client. This is separate from delete behavior and may require tailored copy.**

--END--


[STUD-542]: https://projectnewm.atlassian.net/browse/STUD-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-542]: https://projectnewm.atlassian.net/browse/STUD-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ