### PR TITLE
[STUD-541][Enhancement]: Add three dot action menu and conditional delete release functionality

### DIFF
--- a/apps/studio/src/modules/song/thunks.ts
+++ b/apps/studio/src/modules/song/thunks.ts
@@ -562,17 +562,26 @@ export const getUserWalletSongs = createAsyncThunk(
  * Request to delete user song. If successful, navigate to
  * library and fetch new songs.
  */
+type DeleteSongRedirectVariant = {
+  redirectToReleases?: boolean;
+  request: DeleteSongRequest;
+};
+
 export const deleteSong = createAsyncThunk(
   "song/deleteSong",
-  async (body: DeleteSongRequest, { dispatch }) => {
+  async (body: DeleteSongRequest | DeleteSongRedirectVariant, { dispatch }) => {
     try {
-      // navigate to library page before deleting due to known
+      const request = "request" in body ? body.request : body;
+      const redirectToReleases =
+        "redirectToReleases" in body ? body.redirectToReleases : false;
+
+      // navigate before deleting due to known
       // issue where RTK Query hook will re-fetch data after
       // delete call invalidates cache tag, causing 404 error to
       // display: https://github.com/reduxjs/redux-toolkit/issues/1672
-      history.replace("/home/library");
+      history.replace(redirectToReleases ? "/home/releases" : "/home/library");
 
-      await dispatch(songApi.endpoints.deleteSong.initiate(body));
+      await dispatch(songApi.endpoints.deleteSong.initiate(request));
     } catch (err) {
       // do nothing, errors handled by endpoints
     }

--- a/apps/studio/src/modules/song/thunks.ts
+++ b/apps/studio/src/modules/song/thunks.ts
@@ -560,8 +560,9 @@ export const getUserWalletSongs = createAsyncThunk(
 
 /**
  * Request to delete user song. If successful, navigate to
- * library and fetch new songs.
+ * library / releases (flag variant) and fetch new songs.
  */
+// TODO(webStudioAlbumPhaseOne): Remove redirectToReleases variant once flag is retired.
 type DeleteSongRedirectVariant = {
   redirectToReleases?: boolean;
   request: DeleteSongRequest;

--- a/apps/studio/src/pages/home/releases/DeleteSongModal.tsx
+++ b/apps/studio/src/pages/home/releases/DeleteSongModal.tsx
@@ -15,7 +15,7 @@ const DeleteSongModal: FunctionComponent<DeleteSongModalProps> = ({
   <Stack
     sx={ {
       alignItems: "center",
-      backgroundColor: "black",
+      backgroundColor: theme.colors.backdropBlur,
       bottom: 0,
       display: "flex",
       justifyContent: "center",
@@ -29,29 +29,37 @@ const DeleteSongModal: FunctionComponent<DeleteSongModalProps> = ({
     <Stack p={ 2 }>
       <Stack
         sx={ {
-          backgroundColor: theme.colors.grey500,
+          backgroundColor: theme.colors.black,
           borderTopLeftRadius: "8px",
           borderTopRightRadius: "8px",
-          maxWidth: "512px",
-          padding: "24px 24px 16px",
+          maxWidth: "670px",
+          padding: "24px 24px 10px",
           rowGap: 1,
         } }
       >
-        <Typography variant="body2">Delete Song</Typography>
-        <Typography variant="subtitle1">
-          Are you sure you want to delete this song? Clicking &quot;Yes,&quot;
-          will immediately remove this song from your releases.
+        <Typography fontWeight="fontWeightBold" variant="body2">
+          DELETE RELEASE
+        </Typography>
+        <Typography
+          sx={ {
+            borderBottom: `2px solid ${theme.colors.grey600}`,
+            paddingBottom: 2.5,
+          } }
+          variant="subtitle1"
+        >
+          Are you sure you want to delete this release? All progress and
+          existing metadata will be lost.
         </Typography>
       </Stack>
       <Stack
         sx={ {
-          backgroundColor: theme.colors.grey600,
+          backgroundColor: theme.colors.black,
           borderBottomLeftRadius: "8px",
           borderBottomRightRadius: "8px",
           columnGap: 1.5,
           flexDirection: "row",
           justifyContent: "end",
-          padding: "12px 24px",
+          padding: "10px 24px 24px",
         } }
       >
         <Button
@@ -63,7 +71,7 @@ const DeleteSongModal: FunctionComponent<DeleteSongModalProps> = ({
           Cancel
         </Button>
         <Button width="compact" onClick={ primaryAction }>
-          Yes
+          Delete
         </Button>
       </Stack>
     </Stack>

--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -47,7 +47,7 @@ const Discography: FunctionComponent = () => {
 
       { totalCountOfSongs || query ? (
         <SearchBox
-          placeholder="Search by release name"
+          placeholder="Search by release title"
           query={ query }
           onSearch={ handleSearch }
         />

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -42,6 +42,7 @@ interface EditSongFormValues extends PatchSongThunkRequest {
 }
 
 const EditSong: FunctionComponent = () => {
+  // TODO(webStudioAlbumPhaseOne): Remove flag once flag is retired.
   const { webStudioAlbumPhaseOne } = useFlags();
   const { webStudioDisableTrackDistributionAndMinting } = useFlags();
 

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -104,6 +104,8 @@ const EditSong: FunctionComponent = () => {
     isLoading: isGetSongLoading,
   } = useGetSongQuery(songId);
 
+  const isSongDeletable = getIsSongDeletable(mintingStatus);
+
   const isDeclined = mintingStatus === MintingStatus.Declined;
 
   const owners = collaborations
@@ -312,11 +314,17 @@ const EditSong: FunctionComponent = () => {
         { title && <Typography variant="h3">{ title.toUpperCase() }</Typography> }
 
         <>
-          <Tooltip title={ <ReleaseDeletionHelp /> }>
+          <Tooltip
+            disableFocusListener={ isSongDeletable }
+            disableHoverListener={ isSongDeletable }
+            disableTouchListener={ isSongDeletable }
+            title={ isSongDeletable ? "" : <ReleaseDeletionHelp /> }
+          >
             <Stack ml="auto">
               <Button
                 color="white"
-                disabled={ !getIsSongDeletable(mintingStatus) }
+                // render other status for
+                disabled={ !isSongDeletable }
                 sx={ { marginLeft: "auto" } }
                 variant="outlined"
                 width="icon"

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -42,11 +42,12 @@ interface EditSongFormValues extends PatchSongThunkRequest {
 }
 
 const EditSong: FunctionComponent = () => {
+  const { webStudioAlbumPhaseOne } = useFlags();
+  const { webStudioDisableTrackDistributionAndMinting } = useFlags();
+
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const { songId } = useParams<"songId">() as SongRouteParams;
-
-  const { webStudioDisableTrackDistributionAndMinting } = useFlags();
 
   const { data: genres = [] } = useGetGenresQuery();
   const { data: roles = [] } = useGetRolesQuery();
@@ -340,7 +341,10 @@ const EditSong: FunctionComponent = () => {
           { isDeleteModalActive && (
             <DeleteSongModal
               primaryAction={ () => {
-                deleteSong({ songId });
+                deleteSong({
+                  redirectToReleases: Boolean(webStudioAlbumPhaseOne),
+                  request: { songId },
+                });
               } }
               secondaryAction={ () => {
                 setIsDeleteModalActive(false);

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -343,7 +343,10 @@ const EditSong: FunctionComponent = () => {
               primaryAction={ () => {
                 deleteSong({
                   redirectToReleases: Boolean(webStudioAlbumPhaseOne),
-                  request: { songId },
+                  request: {
+                    archived: true,
+                    songId,
+                  },
                 });
               } }
               secondaryAction={ () => {

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -444,22 +444,15 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
                 <TableCell>
                   <Box sx={ { alignItems: "center", display: "flex" } }>
                     { isSongStale ? (
-                      <Tooltip
-                        title={
-                          "The file couldn't be uploaded. Please try again, " +
-                          `or reach out to ${NEWM_SUPPORT_EMAIL} for further assistance.`
-                        }
-                      >
-                        <CloseIcon
-                          color="error"
-                          sx={ {
-                            height: "24px",
-                            marginLeft: [0, 1],
-                            marginRight: [2, 4],
-                            width: "40px",
-                          } }
-                        />
-                      </Tooltip>
+                      <CloseIcon
+                        color="error"
+                        sx={ {
+                          height: "24px",
+                          marginLeft: [0, 1],
+                          marginRight: [2, 4],
+                          width: "40px",
+                        } }
+                      />
                     ) : (
                       <IconButton
                         sx={ {
@@ -541,23 +534,20 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
                 >
                   { isSongStale ? (
                     <Tooltip
-                      placement="right"
+                      placement="left"
                       title="There was an issue processing your release's audio. Please contact support for assistance."
                     >
-                      <Link
+                      <Button
+                        aria-label="Contact support"
+                        color="music"
                         href={ NEWM_SUPPORT_LINK }
                         rel="noopener noreferrer"
                         target="_blank"
+                        variant="secondary"
+                        onClick={ (event) => event.stopPropagation() }
                       >
-                        <Button
-                          aria-label="Contact support"
-                          color="music"
-                          variant="secondary"
-                          onClick={ (event) => event.stopPropagation() }
-                        >
-                          Support
-                        </Button>
-                      </Link>
+                        Support
+                      </Button>
                     </Tooltip>
                   ) : (
                     <ActionMenuTrigger onClick={ handleMenuOpen(song) } />

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -261,6 +261,7 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
 
   const handleMenuClose = () => {
     setMenuAnchorEl(null);
+    setMenuSong(null);
   };
 
   const clearPendingSaleStorage = (songId: string) => {

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -398,6 +398,11 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
     setPage(1);
   }, [query]);
 
+  useEffect(() => {
+    setMenuAnchorEl(null);
+    setMenuSong(null);
+  }, [page, query, songData]);
+
   // Keep song in a playing state till the song has been filtered out
   useEffect(() => {
     const isSongFound = !!songData?.find((song) => {

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -401,7 +401,11 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
         id: "view-edit",
         label: "View / Edit",
         onClick: () => {
-          navigate(`/home/releases/edit-song/${menuSong.id}`);
+          if (menuSongIsEditable) {
+            navigate(`/home/releases/edit-song/${menuSong.id}`);
+          } else {
+            navigate(`/home/releases/view-details/${menuSong.id}`);
+          }
         },
       },
       {

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -53,7 +53,6 @@ import {
   useGetSongsQuery,
 } from "../../../modules/song";
 import {
-  NEWM_SUPPORT_EMAIL,
   NEWM_SUPPORT_LINK,
   PlayerState,
   isSongEditable as isSongEditableUtil,
@@ -76,6 +75,7 @@ const FINAL_STEP_MINTING_PROCESS = [
 ];
 
 export default function SongList({ totalCountOfSongs, query }: SongListProps) {
+  // TODO(webStudioAlbumPhaseOne): Remove flag once flag is retired.
   const { webStudioAlbumPhaseOne } = useFlags();
 
   const navigate = useNavigate();
@@ -293,9 +293,14 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
     if (isErrorMintingStatus) {
       content = (
         <span>
-          An error has occurred. Please reach out to{ " " }
-          <Link href={ `mailto:${NEWM_SUPPORT_EMAIL}` }>
-            { NEWM_SUPPORT_EMAIL }
+          An error has occurred. Please reach out via the{ " " }
+          <Link
+            href={ NEWM_SUPPORT_LINK }
+            rel="noopener noreferrer"
+            target="_blank"
+            onClick={ (event) => event.stopPropagation() }
+          >
+            NEWM Support Portal
           </Link>{ " " }
           for assistance distributing your release.
         </span>
@@ -349,7 +354,7 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
           setIsDeleteModalActive(true);
         },
         tooltip: !isMenuSongDeletable ? <ReleaseDeletionHelp /> : undefined,
-        tooltipPlacement: "right",
+        tooltipPlacement: "left",
       },
     ];
 

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -317,10 +317,6 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
   const isMenuSongDeletable = menuSong
     ? getIsSongDeletable(menuSong.mintingStatus)
     : false;
-  const isMenuSongStale =
-    !!menuSong &&
-    isMoreThanThresholdSecondsLater(menuSong.createdAt, 1200) &&
-    !menuSong.streamUrl;
 
   const actionMenuItems = useMemo<ReadonlyArray<ActionMenuItem>>(() => {
     if (!menuSong) return [];
@@ -543,7 +539,7 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
                     width: "0",
                   } }
                 >
-                  { isMenuSongStale ? (
+                  { isSongStale ? (
                     <Tooltip
                       placement="right"
                       title="There was an issue processing your release's audio. Please contact support for assistance."

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -1,10 +1,4 @@
-import React, {
-  MouseEvent,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import React, { MouseEvent, useEffect, useMemo, useState } from "react";
 import {
   Box,
   IconButton,
@@ -26,6 +20,7 @@ import {
   ActionMenuTrigger,
 } from "@newm-web/components";
 import {
+  Button,
   TableCell,
   TablePagination,
   TableSkeleton,
@@ -61,6 +56,7 @@ import {
   LOCAL_STORAGE_SALE_END_PENDING_KEY,
   LOCAL_STORAGE_SALE_START_PENDING_KEY,
   NEWM_SUPPORT_EMAIL,
+  NEWM_SUPPORT_LINK,
   PlayerState,
   isSongEditable as isSongEditableUtil,
   useAppDispatch,
@@ -335,21 +331,6 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
     setMenuSong(null);
   };
 
-  const handleEmailSupport = useCallback(
-    (event: MouseEvent, songId: string) => {
-      event.stopPropagation();
-
-      const mailtoLink =
-        `mailto:${NEWM_SUPPORT_EMAIL}` +
-        "?subject=Support Request" +
-        "&body=" +
-        encodeURIComponent(`The following Song ID failed to encode: ${songId}`);
-
-      window.location.href = mailtoLink;
-    },
-    []
-  );
-
   const getTooltipContent = (mintingStatus: MintingStatusType) => {
     const isErrorMintingStatus =
       ErrorOccurredMintingStatuses.includes(mintingStatus);
@@ -422,26 +403,8 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
       },
     ];
 
-    if (isMenuSongStale) {
-      items.push({
-        dividerAbove: true,
-        id: "support",
-        label: "Support",
-        onClick: (event) => {
-          handleEmailSupport(event, menuSong.id);
-        },
-      });
-    }
-
     return items;
-  }, [
-    handleEmailSupport,
-    isMenuSongDeletable,
-    isMenuSongStale,
-    menuSong,
-    menuSongIsEditable,
-    navigate,
-  ]);
+  }, [isMenuSongDeletable, menuSong, menuSongIsEditable, navigate]);
 
   useEffect(() => {
     setPage(1);
@@ -621,7 +584,29 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
                     width: "0",
                   } }
                 >
-                  <ActionMenuTrigger onClick={ handleMenuOpen(song) } />
+                  { isMenuSongStale ? (
+                    <Tooltip
+                      placement="right"
+                      title="There was an issue processing your release's audio. Please contact support for assistance."
+                    >
+                      <Link
+                        href={ NEWM_SUPPORT_LINK }
+                        rel="noopener noreferrer"
+                        target="_blank"
+                      >
+                        <Button
+                          aria-label="Contact support"
+                          color="music"
+                          variant="secondary"
+                          onClick={ (event) => event.stopPropagation() }
+                        >
+                          Support
+                        </Button>
+                      </Link>
+                    </Tooltip>
+                  ) : (
+                    <ActionMenuTrigger onClick={ handleMenuOpen(song) } />
+                  ) }
                 </TableCell>
               </TableRow>
             );

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -28,7 +28,6 @@ import {
 } from "@newm-web/elements";
 import {
   isMoreThanThresholdSecondsLater,
-  parseStoredJSON,
   resizeCloudinaryImage,
   useHlsJs,
   useWindowDimensions,
@@ -54,9 +53,6 @@ import {
   useGetSongsQuery,
 } from "../../../modules/song";
 import {
-  LOCAL_STORAGE_SALE_COMPLETE_PENDING_KEY,
-  LOCAL_STORAGE_SALE_END_PENDING_KEY,
-  LOCAL_STORAGE_SALE_START_PENDING_KEY,
   NEWM_SUPPORT_EMAIL,
   NEWM_SUPPORT_LINK,
   PlayerState,
@@ -267,41 +263,6 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
     setMenuSong(null);
   };
 
-  const clearPendingSaleStorage = (songId: string) => {
-    const clearSongFromArray = (storageKey: string) => {
-      const parsed = parseStoredJSON<string[]>(storageKey);
-      if (!Array.isArray(parsed)) return;
-
-      const nextValue = parsed.filter((id) => id !== songId);
-      if (nextValue.length) {
-        localStorage.setItem(storageKey, JSON.stringify(nextValue));
-      } else {
-        localStorage.removeItem(storageKey);
-      }
-    };
-
-    const clearSongFromMap = (storageKey: string) => {
-      const parsed = parseStoredJSON<Record<string, unknown>>(storageKey);
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        return;
-      }
-
-      if (!(songId in parsed)) return;
-
-      delete parsed[songId];
-
-      if (Object.keys(parsed).length) {
-        localStorage.setItem(storageKey, JSON.stringify(parsed));
-      } else {
-        localStorage.removeItem(storageKey);
-      }
-    };
-
-    clearSongFromMap(LOCAL_STORAGE_SALE_START_PENDING_KEY);
-    clearSongFromArray(LOCAL_STORAGE_SALE_END_PENDING_KEY);
-    clearSongFromArray(LOCAL_STORAGE_SALE_COMPLETE_PENDING_KEY);
-  };
-
   const handleDeleteConfirm = async () => {
     if (!pendingDeleteSong) return;
 
@@ -309,7 +270,6 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
       stopSong();
     }
 
-    clearPendingSaleStorage(pendingDeleteSong.id);
     await deleteSong({
       redirectToReleases: Boolean(webStudioAlbumPhaseOne),
       request: {

--- a/apps/studio/src/pages/home/releases/SongList.tsx
+++ b/apps/studio/src/pages/home/releases/SongList.tsx
@@ -393,7 +393,11 @@ export default function SongList({ totalCountOfSongs, query }: SongListProps) {
 
     const items: ActionMenuItem[] = [
       {
-        icon: menuSongIsEditable ? <EditIcon /> : <VisibilityIcon />,
+        icon: menuSongIsEditable ? (
+          <EditIcon fontSize="small" />
+        ) : (
+          <VisibilityIcon fontSize="small" />
+        ),
         id: "view-edit",
         label: "View / Edit",
         onClick: () => {

--- a/apps/studio/src/pages/home/releases/Table/TableHead.tsx
+++ b/apps/studio/src/pages/home/releases/Table/TableHead.tsx
@@ -5,7 +5,7 @@ const TableHead = () => {
   return (
     <MUITableHead>
       <TableRow>
-        <TableHeadCell>RELEASE NAME</TableHeadCell>
+        <TableHeadCell>RELEASE TITLE</TableHeadCell>
         <TableHeadCell sx={ { display: { sm: "table-cell", xs: "none" } } }>
           RELEASE STATUS
         </TableHeadCell>
@@ -23,6 +23,7 @@ const TableHead = () => {
         >
           LENGTH
         </TableHeadCell>
+        <TableHeadCell sx={ { textAlign: "end" } } />
       </TableRow>
     </MUITableHead>
   );

--- a/packages/components/jest.config.ts
+++ b/packages/components/jest.config.ts
@@ -7,5 +7,6 @@ export default {
     "^.+\\.[tj]sx?$": ["babel-jest", { presets: ["@nx/react/babel"] }],
   },
   moduleFileExtensions: ["ts", "tsx", "js", "jsx"],
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.js"],
   coverageDirectory: "../../coverage/packages/components",
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,8 @@
 export { default as Alert } from "./lib/Alert";
+export * from "./lib/ActionMenu";
+export { default as ActionMenu } from "./lib/ActionMenu";
+export * from "./lib/ActionMenuTrigger";
+export { default as ActionMenuTrigger } from "./lib/ActionMenuTrigger";
 export * from "./lib/buttons/DisconnectWalletButton";
 export { default as DisconnectWalletButton } from "./lib/buttons/DisconnectWalletButton";
 export { default as EarningsClaimInProgress } from "./lib/earnings/EarningsClaimInProgress";

--- a/packages/components/src/lib/ActionMenu.tsx
+++ b/packages/components/src/lib/ActionMenu.tsx
@@ -22,6 +22,11 @@ export type ActionMenuItem = {
   readonly icon?: ReactNode;
   readonly id: string;
   readonly label: string;
+  readonly link?: {
+    readonly href: string;
+    readonly rel?: string;
+    readonly target?: string;
+  };
   readonly onClick?: (event: MouseEvent<HTMLLIElement>) => void;
   readonly tooltip?: ReactNode;
   readonly tooltipPlacement?: TooltipProps["placement"];
@@ -132,9 +137,27 @@ const ActionMenu: FunctionComponent<ActionMenuProps> = ({
         const shouldShowDivider =
           showDividers && index < items.length - 1 && !item.dividerAbove;
 
+        const linkRel =
+          item.link?.target === "_blank" && !item.link.rel
+            ? "noopener noreferrer"
+            : item.link?.rel;
+
+        const linkProps = item.link
+          ? {
+              component: "a" as const,
+              href: item.link.href,
+              rel: linkRel,
+              style: {
+                width: "100%",
+              },
+              target: item.link.target,
+            }
+          : {};
+
         const menuItem = (
           <MenuItem
             disabled={ item.disabled }
+            { ...linkProps }
             sx={ {
               "&:hover": {
                 backgroundColor: theme.colors.grey500,

--- a/packages/components/src/lib/ActionMenu.tsx
+++ b/packages/components/src/lib/ActionMenu.tsx
@@ -1,0 +1,200 @@
+import { FunctionComponent, MouseEvent, ReactNode } from "react";
+
+import {
+  Box,
+  Divider,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  PopoverOrigin,
+  TooltipProps,
+} from "@mui/material";
+import { SxProps, Theme } from "@mui/material/styles";
+
+import { Tooltip } from "@newm-web/elements";
+import theme from "@newm-web/theme";
+
+export type ActionMenuItem = {
+  readonly color?: "default" | "danger";
+  readonly disabled?: boolean;
+  readonly dividerAbove?: boolean;
+  readonly icon?: ReactNode;
+  readonly id: string;
+  readonly label: string;
+  readonly onClick?: (event: MouseEvent<HTMLLIElement>) => void;
+  readonly tooltip?: ReactNode;
+  readonly tooltipPlacement?: TooltipProps["placement"];
+};
+
+interface ActionMenuProps {
+  readonly anchorEl: HTMLElement | null;
+  readonly anchorOrigin?: PopoverOrigin;
+  readonly closeOnSelect?: boolean;
+  readonly itemSx?: SxProps<Theme>;
+  readonly items: ReadonlyArray<ActionMenuItem>;
+  readonly menuListSx?: SxProps<Theme>;
+  readonly menuPaperSx?: SxProps<Theme>;
+  readonly minWidth?: number | string;
+  readonly onClose: () => void;
+  readonly open: boolean;
+  readonly showDividers?: boolean;
+  readonly stopPropagation?: boolean;
+  readonly transformOrigin?: PopoverOrigin;
+}
+
+const DEFAULT_ANCHOR_ORIGIN: PopoverOrigin = {
+  horizontal: "left",
+  vertical: "bottom",
+};
+const DEFAULT_TRANSFORM_ORIGIN: PopoverOrigin = {
+  horizontal: "right",
+  vertical: "top",
+};
+
+const ActionMenu: FunctionComponent<ActionMenuProps> = ({
+  anchorEl,
+  anchorOrigin = DEFAULT_ANCHOR_ORIGIN,
+  closeOnSelect = true,
+  itemSx,
+  items,
+  menuListSx,
+  menuPaperSx,
+  minWidth = "192px",
+  onClose,
+  open,
+  showDividers = true,
+  stopPropagation = true,
+  transformOrigin = DEFAULT_TRANSFORM_ORIGIN,
+}) => {
+  const handleMenuClick = (event: MouseEvent) => {
+    if (stopPropagation) {
+      event.stopPropagation();
+    }
+  };
+
+  const getItemColor = (item: ActionMenuItem) => {
+    if (item.disabled) {
+      return theme.colors.grey100;
+    }
+
+    if (item.color === "danger") {
+      return theme.colors.red;
+    }
+
+    return theme.colors.white;
+  };
+
+  const handleItemClick =
+    (item: ActionMenuItem) => (event: MouseEvent<HTMLLIElement>) => {
+      if (stopPropagation) {
+        event.stopPropagation();
+      }
+
+      item.onClick?.(event);
+
+      if (closeOnSelect) {
+        onClose();
+      }
+    };
+
+  return (
+    <Menu
+      anchorEl={ anchorEl }
+      anchorOrigin={ anchorOrigin }
+      MenuListProps={ {
+        sx: {
+          paddingBottom: 0,
+          paddingTop: 0,
+          ...menuListSx,
+        },
+      } }
+      open={ open }
+      slotProps={ {
+        paper: {
+          sx: {
+            backgroundColor: theme.colors.grey600,
+            border: `2px solid ${theme.colors.grey500}`,
+            borderRadius: "4px",
+            minWidth,
+            paddingBottom: 0,
+            paddingTop: 0,
+            ...menuPaperSx,
+          },
+        },
+      } }
+      transformOrigin={ transformOrigin }
+      onClick={ handleMenuClick }
+      onClose={ onClose }
+    >
+      { items.map((item, index) => {
+        const itemColor = getItemColor(item);
+        const shouldShowDivider =
+          showDividers && index < items.length - 1 && !item.dividerAbove;
+
+        const menuItem = (
+          <MenuItem
+            disabled={ item.disabled }
+            sx={ {
+              "&:hover": {
+                backgroundColor: theme.colors.grey500,
+              },
+              color: itemColor,
+              cursor: item.disabled ? "not-allowed" : "pointer",
+              paddingX: 2,
+              paddingY: 1.25,
+              ...itemSx,
+            } }
+            onClick={ handleItemClick(item) }
+          >
+            <ListItemIcon
+              sx={ {
+                color: itemColor,
+                minWidth: 0,
+                opacity: item.icon ? 1 : 0,
+                width: "20px",
+              } }
+            >
+              { item.icon }
+            </ListItemIcon>
+            <ListItemText primary={ item.label } />
+          </MenuItem>
+        );
+
+        return (
+          <Box key={ item.id }>
+            { item.dividerAbove && (
+              <Divider
+                sx={ {
+                  backgroundColor: theme.colors.grey500,
+                  height: "2px",
+                  margin: "0 !important",
+                } }
+              />
+            ) }
+            { item.tooltip ? (
+              <Tooltip placement={ item.tooltipPlacement } title={ item.tooltip }>
+                <Box component="span" sx={ { display: "flex" } }>
+                  { menuItem }
+                </Box>
+              </Tooltip>
+            ) : (
+              menuItem
+            ) }
+            { shouldShowDivider && (
+              <Divider
+                sx={ {
+                  backgroundColor: theme.colors.grey500,
+                  height: "2px",
+                  margin: "0 !important",
+                } }
+              />
+            ) }
+          </Box>
+        );
+      }) }
+    </Menu>
+  );
+};
+
+export default ActionMenu;

--- a/packages/components/src/lib/ActionMenuTrigger.tsx
+++ b/packages/components/src/lib/ActionMenuTrigger.tsx
@@ -20,9 +20,7 @@ const ActionMenuTrigger: FunctionComponent<ActionMenuTriggerProps> = ({
   return (
     <Button
       aria-label={ ariaLabel }
-      sx={ {
-        ...sx,
-      } }
+      sx={ sx }
       variant="secondary"
       width="icon"
       onClick={ onClick }

--- a/packages/components/src/lib/ActionMenuTrigger.tsx
+++ b/packages/components/src/lib/ActionMenuTrigger.tsx
@@ -1,0 +1,35 @@
+import { FunctionComponent, ReactNode } from "react";
+
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+
+import { Button, ButtonProps } from "@newm-web/elements";
+import theme from "@newm-web/theme";
+
+export interface ActionMenuTriggerProps
+  extends Omit<ButtonProps, "children" | "variant" | "width"> {
+  readonly ariaLabel?: string;
+  readonly icon?: ReactNode;
+}
+
+const ActionMenuTrigger: FunctionComponent<ActionMenuTriggerProps> = ({
+  ariaLabel = "Open actions",
+  icon = <MoreVertIcon sx={ { color: theme.colors.music } } />,
+  onClick,
+  sx,
+}) => {
+  return (
+    <Button
+      aria-label={ ariaLabel }
+      sx={ {
+        ...sx,
+      } }
+      variant="secondary"
+      width="icon"
+      onClick={ onClick }
+    >
+      { icon }
+    </Button>
+  );
+};
+
+export default ActionMenuTrigger;

--- a/packages/components/src/lib/test/ActionMenu.test.tsx
+++ b/packages/components/src/lib/test/ActionMenu.test.tsx
@@ -1,0 +1,115 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { renderWithContext } from "./utils/render";
+import ActionMenu, { ActionMenuItem } from "../ActionMenu";
+
+describe("<ActionMenu />", () => {
+  const buildAnchor = () => {
+    const anchor = document.createElement("button");
+    document.body.appendChild(anchor);
+    return anchor;
+  };
+
+  const baseItems: ActionMenuItem[] = [
+    {
+      id: "view-edit",
+      label: "View / Edit",
+      onClick: jest.fn(),
+    },
+    {
+      id: "delete",
+      label: "Delete",
+      onClick: jest.fn(),
+    },
+  ];
+
+  it("renders menu items when open", () => {
+    const anchorEl = buildAnchor();
+
+    renderWithContext(
+      <ActionMenu
+        anchorEl={ anchorEl }
+        items={ baseItems }
+        open={ true }
+        onClose={ jest.fn() }
+      />
+    );
+
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "View / Edit" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Delete" })
+    ).toBeInTheDocument();
+
+    document.body.removeChild(anchorEl);
+  });
+
+  it("invokes item click and closes by default", async () => {
+    const anchorEl = buildAnchor();
+    const onClose = jest.fn();
+    const onClick = jest.fn();
+
+    renderWithContext(
+      <ActionMenu
+        anchorEl={ anchorEl }
+        items={ [{ id: "view", label: "View", onClick }] }
+        open={ true }
+        onClose={ onClose }
+      />
+    );
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "View" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(anchorEl);
+  });
+
+  it("does not close when closeOnSelect is false", async () => {
+    const anchorEl = buildAnchor();
+    const onClose = jest.fn();
+
+    renderWithContext(
+      <ActionMenu
+        anchorEl={ anchorEl }
+        closeOnSelect={ false }
+        items={ [{ id: "view", label: "View", onClick: jest.fn() }] }
+        open={ true }
+        onClose={ onClose }
+      />
+    );
+
+    await userEvent.click(screen.getByRole("menuitem", { name: "View" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+
+    document.body.removeChild(anchorEl);
+  });
+
+  it("disables menu items and renders dividers by default", () => {
+    const anchorEl = buildAnchor();
+
+    renderWithContext(
+      <ActionMenu
+        anchorEl={ anchorEl }
+        items={ [
+          { id: "view", label: "View" },
+          { disabled: true, id: "delete", label: "Delete" },
+        ] }
+        open={ true }
+        onClose={ jest.fn() }
+      />
+    );
+
+    const deleteItem = screen.getByRole("menuitem", { name: "Delete" });
+
+    expect(deleteItem).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getAllByRole("separator")).toHaveLength(1);
+
+    document.body.removeChild(anchorEl);
+  });
+});

--- a/packages/components/src/lib/test/ActionMenu.test.tsx
+++ b/packages/components/src/lib/test/ActionMenu.test.tsx
@@ -47,6 +47,34 @@ describe("<ActionMenu />", () => {
     document.body.removeChild(anchorEl);
   });
 
+  it("renders menu items as links when href is provided", () => {
+    const anchorEl = buildAnchor();
+
+    renderWithContext(
+      <ActionMenu
+        anchorEl={ anchorEl }
+        items={ [
+          {
+            id: "support",
+            label: "Support",
+            link: {
+              href: "https://example.com/support",
+              target: "_blank",
+            },
+          },
+        ] }
+        open={ true }
+        onClose={ jest.fn() }
+      />
+    );
+
+    const supportItem = screen.getByRole("menuitem", { name: "Support" });
+
+    expect(supportItem).toHaveAttribute("href", "https://example.com/support");
+
+    document.body.removeChild(anchorEl);
+  });
+
   it("invokes item click and closes by default", async () => {
     const anchorEl = buildAnchor();
     const onClose = jest.fn();

--- a/packages/components/src/lib/test/ActionMenuTrigger.test.tsx
+++ b/packages/components/src/lib/test/ActionMenuTrigger.test.tsx
@@ -1,0 +1,35 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { renderWithContext } from "./utils/render";
+import ActionMenuTrigger from "../ActionMenuTrigger";
+
+describe("<ActionMenuTrigger />", () => {
+  it("renders the default trigger button", () => {
+    renderWithContext(<ActionMenuTrigger onClick={ jest.fn() } />);
+
+    expect(
+      screen.getByRole("button", { name: "Open actions" })
+    ).toBeInTheDocument();
+  });
+
+  it("invokes onClick when pressed", async () => {
+    const onClick = jest.fn();
+
+    renderWithContext(<ActionMenuTrigger onClick={ onClick } />);
+
+    await userEvent.click(screen.getByRole("button", { name: "Open actions" }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports a custom aria label", () => {
+    renderWithContext(
+      <ActionMenuTrigger ariaLabel="Row actions" onClick={ jest.fn() } />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Row actions" })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/components/src/lib/test/utils/render.tsx
+++ b/packages/components/src/lib/test/utils/render.tsx
@@ -1,0 +1,16 @@
+import { ReactElement } from "react";
+import { RenderOptions, render } from "@testing-library/react";
+import { WrapperProps } from "@newm-web/utils";
+import { ThemeProvider } from "@mui/material/styles";
+import theme from "@newm-web/theme";
+
+export const renderWithContext = (
+  ui: ReactElement,
+  options: RenderOptions = {}
+) => {
+  const Wrapper = ({ children }: WrapperProps) => {
+    return <ThemeProvider theme={ theme }>{ children }</ThemeProvider>;
+  };
+
+  return render(ui, { wrapper: Wrapper, ...options });
+};

--- a/packages/components/src/setupTests.js
+++ b/packages/components/src/setupTests.js
@@ -1,0 +1,11 @@
+import "@testing-library/jest-dom";
+
+jest.mock("@newm-web/env", () => ({
+  APPLE_CLIENT_ID: "EXAMPLE_ID",
+  GOOGLE_CLIENT_ID: "EXAMPLE_ID",
+  GA_STUDIO_ID: "EXAMPLE_ID",
+  NX_CLOUD_ACCESS_TOKEN: "EXAMPLE_TOKEN",
+  NODE_ENV: "test",
+  ENV: "test",
+  isProd: false
+}));

--- a/packages/elements/src/lib/styled/GradientDashedOutline.tsx
+++ b/packages/elements/src/lib/styled/GradientDashedOutline.tsx
@@ -26,7 +26,9 @@ const GradientDashedOutline = styled(Box, {
   backgroundImage: `linear-gradient(${theme.colors.grey700}, ${theme.colors.grey700}), ${theme.gradients[gradient]}`,
   backgroundOrigin: "padding-box, border-box",
   border: `2px dashed ${theme.colors.grey700}`,
+  borderRadius: 5,
 
-  borderRadius: 4,
+  borderWidth: "2.5px",
 }));
+
 export default GradientDashedOutline;

--- a/packages/elements/src/lib/styled/GradientDashedOutline.tsx
+++ b/packages/elements/src/lib/styled/GradientDashedOutline.tsx
@@ -25,10 +25,8 @@ const GradientDashedOutline = styled(Box, {
 
   backgroundImage: `linear-gradient(${theme.colors.grey700}, ${theme.colors.grey700}), ${theme.gradients[gradient]}`,
   backgroundOrigin: "padding-box, border-box",
-  border: `2px dashed ${theme.colors.grey700}`,
+  border: `2.5px dashed ${theme.colors.grey700}`,
   borderRadius: 5,
-
-  borderWidth: "2.5px",
 }));
 
 export default GradientDashedOutline;

--- a/packages/utils/src/lib/storage.ts
+++ b/packages/utils/src/lib/storage.ts
@@ -22,6 +22,17 @@ export const LocalStorage = {
   },
 };
 
+export const parseStoredJSON = <T = unknown>(key: string): T | undefined => {
+  const value = LocalStorage.getItem(key);
+  if (!value) return undefined;
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    return undefined;
+  }
+};
+
 const storageAvailable = (type: string) => {
   let storage;
 

--- a/packages/utils/src/lib/test/storage.test.ts
+++ b/packages/utils/src/lib/test/storage.test.ts
@@ -1,0 +1,74 @@
+import { LocalStorage, parseStoredJSON } from "../storage";
+
+describe("LocalStorage", () => {
+  const mockStorage = () => {
+    const store: Record<string, string> = {};
+
+    return {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+    };
+  };
+
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: mockStorage(),
+      writable: true,
+    });
+  });
+
+  it("sets and gets stored values", () => {
+    LocalStorage.setItem("test-key", "test-value");
+
+    expect(LocalStorage.getItem("test-key")).toEqual("test-value");
+  });
+
+  it("returns null for missing keys", () => {
+    expect(LocalStorage.getItem("missing")).toBeNull();
+  });
+
+  it("removes stored values", () => {
+    LocalStorage.setItem("test-key", "test-value");
+    LocalStorage.removeItem("test-key");
+
+    expect(LocalStorage.getItem("test-key")).toBeNull();
+  });
+});
+
+describe("parseStoredJSON", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+      },
+      writable: true,
+    });
+  });
+
+  it("returns undefined when the key is missing", () => {
+    (window.localStorage.getItem as jest.Mock).mockReturnValue(null);
+
+    expect(parseStoredJSON("missing")).toBeUndefined();
+  });
+
+  it("returns parsed JSON for valid values", () => {
+    (window.localStorage.getItem as jest.Mock).mockReturnValue(
+      JSON.stringify({ id: "abc" })
+    );
+
+    expect(parseStoredJSON<{ id: string }>("data")).toEqual({ id: "abc" });
+  });
+
+  it("returns undefined when JSON is invalid", () => {
+    (window.localStorage.getItem as jest.Mock).mockReturnValue("not-json");
+
+    expect(parseStoredJSON("data")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Pull Request — Issue [STUD-541](https://projectnewm.atlassian.net/browse/STUD-541)

## Overview

> Adds a three-dot action menu to Releases rows with View/Edit and conditional Delete, including confirmation modal, tooltip gating, and localStorage cleanup.  
> Also introduces reusable ActionMenu/ActionMenuTrigger components (with tests) to standardize action menus across the app.
>
> **Other tickets minor changes:**
>
> - `GradientDashedOutline` style updates. Refer to [STUD-539-comments](https://projectnewm.atlassian.net/browse/STUD-539?focusedCommentId=21120)
> - `TableHead` copy updates. Refer to [STUD-540-comments](https://projectnewm.atlassian.net/browse/STUD-540?focusedCommentId=21108)
> - `EditSong` tooltip only renders when non-deletable. Refer to [STUD-542-comments](https://projectnewm.atlassian.net/browse/STUD-542?focusedCommentId=21111)

---

## Files Summary

> **Total Changes:** 17 files  
> (Counts of added, modified, and deleted files can be seen in the PR diff view.)

<details>
<summary>Added (7)</summary>

- **`packages/components/src/lib/ActionMenu.tsx`**
  - — Reusable action menu with configurable items, tooltips, dividers, and anchors.
- **`packages/components/src/lib/ActionMenuTrigger.tsx`**
  - — Standardized kebab trigger button for action menus.
- **`packages/components/src/lib/test/ActionMenu.test.tsx`**
  - — Unit tests for ActionMenu behaviors.
- **`packages/components/src/lib/test/ActionMenuTrigger.test.tsx`**
  - — Unit tests for ActionMenuTrigger.
-**`packages/utils/src/lib/storage.test.ts`.
   - — Unit tests for all storage-related functions. 

  - **`ActionMenuTrigger` is kept separate from `ActionMenu` so the menu remains anchor‑agnostic and reusable; different screens can supply their own trigger (kebab, text button, icon) without coupling layout/trigger styling to the menu component.**

- **`packages/components/src/lib/test/utils/render.tsx`**
  - — Shared test renderer with theme provider.
- **`packages/components/src/setupTests.js`**
  - — Jest setup with env mocks for components package.

</details>

<details>
<summary>Modified (10)</summary>

- **`apps/studio/src/pages/home/releases/SongList.tsx`**
  - — Adds row action menu, delete flow (archived:true), and pending-sale localStorage cleanup.
- **`apps/studio/src/pages/home/releases/EditSong.tsx`**
  - — Delete tooltip only renders when non-deletable.
- **`apps/studio/src/pages/home/releases/DeleteSongModal.tsx`**
  - — Copy and styling tweaks for deletion confirmation.
- **`apps/studio/src/pages/home/releases/Table/TableHead.tsx`**
  - — Header copy updates and action column alignment.
- **`apps/studio/src/pages/home/releases/Discography.tsx`**
  - — Search placeholder/copy updates.
- **`packages/components/jest.config.ts`**
  - — Adds setupTests for components test environment.
- **`packages/components/src/index.ts`**
  - — Exports new ActionMenu/Trigger components.
- **`packages/elements/src/lib/styled/GradientDashedOutline.tsx`**
  - — Style updates to match refreshed UI.
-**`packages/utils/src/lib/storage.ts`.
   - — Added new `parseStoredJSON` func.
-**`packages/utils/src/lib/storage.ts`.
   - — Added a backward‑compatible new `deleteSong` argument variant to optionally redirect to /home/releases while keeping existing callers unchanged.

</details>

<details>
<summary>Deleted (0)</summary>

- _None._

</details>

---

## Impact

- Releases table now uses a consistent action menu for View/Edit and conditional Delete.
- Delete action is gated by release status and shows tooltip only when non-deletable.
- New reusable components standardize menu styling and behavior across the app.
- LocalStorage cleanup removes stale pending-sale entries upon delete confirm.

---

## Testing

- Run:
  - `npx nx test components --testPathPattern=ActionMenu.test.tsx`
  - `npx nx test components --testPathPattern=ActionMenuTrigger.test.tsx`
  - `npx nx test utils --testPathPattern=storage.test.ts`

---

## Related Issues

- Closes [STUD-541](https://projectnewm.atlassian.net/browse/STUD-541)
- Addresses minor ticket comments: [STUD-539-comments](https://projectnewm.atlassian.net/browse/STUD-539?focusedCommentId=21120), [STUD-540-comments](https://projectnewm.atlassian.net/browse/STUD-540?focusedCommentId=21108) and [STUD-542-comments](https://projectnewm.atlassian.net/browse/STUD-542?focusedCommentId=21111).

---

## Dependencies

- No new dependencies.

---

## Demo

<img width="1356" height="621" alt="STUD-541-delete-tooltip" src="https://github.com/user-attachments/assets/134c3598-d21b-44a4-885c-14753f1a69ec" />

_Note: The delete tooltip uses the reusable `ReleaseDeletionHelp` component, so its `width/line‑wrap` differs slightly from Figma._

https://github.com/user-attachments/assets/b2decebc-b21a-4d5d-9345-86fe005f0101

_Note: Edit/Visibility icons now have correct size [8aa7a1](https://github.com/projectNEWM/newm-web/pull/936/commits/8aa7a1436134ad3aaaa2556bc2c4fedd3cdabec2)._

---

## Additional Notes

- Delete action uses `archived: true` via the existing `deleteSong` endpoint.
- Tooltip for Delete only renders when the status is not deletable.
- The localStorage cleanup repeats similar parse/remove logic for array vs map; if this expands, we should consider extracting a shared utility.

--END--


[STUD-541]: https://projectnewm.atlassian.net/browse/STUD-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-539]: https://projectnewm.atlassian.net/browse/STUD-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-541]: https://projectnewm.atlassian.net/browse/STUD-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ