### PR TITLE
[STUD-552][Feature]: Sub task 1 - Page, Main layout, some routes, Add New Track button and minimal tracks scaffold.

### DIFF
--- a/apps/studio/src/pages/home/Home.tsx
+++ b/apps/studio/src/pages/home/Home.tsx
@@ -26,20 +26,26 @@ import { useGetStudioClientConfigQuery } from "../../modules/content";
 import { identifyReferralHeroUser } from "../../common";
 import NotFoundPage from "../NotFoundPage";
 
+const RELEASES_BASE_PATH = "releases";
+
 const Home: FunctionComponent = () => {
   const drawerWidth = 230;
   const theme = useTheme();
   const navigate = useNavigate();
 
   // TODO(webStudioAlbumPhaseOne): Remove flag once flag is retired.
-  const { webStudioAlbumPhaseOne, webStudioArtistReferralCampaign } =
-    useFlags();
+  // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
+  const {
+    webStudioAlbumPhaseOne,
+    webStudioAlbumPhaseTwo,
+    webStudioArtistReferralCampaign,
+  } = useFlags();
 
   const routeLocation = useLocation();
 
   const libraryRedirectPath = routeLocation.pathname.replace(
     "/home/library",
-    "/home/releases"
+    `/home/${RELEASES_BASE_PATH}`
   );
 
   const [isMobileOpen, setMobileOpen] = useState(false);
@@ -114,7 +120,11 @@ const Home: FunctionComponent = () => {
           <Route
             element={
               <Navigate
-                to={ webStudioAlbumPhaseOne ? "releases" : "upload-song" }
+                to={
+                  webStudioAlbumPhaseOne || webStudioAlbumPhaseTwo
+                    ? RELEASES_BASE_PATH
+                    : "upload-song"
+                }
                 replace
               />
             }
@@ -125,7 +135,7 @@ const Home: FunctionComponent = () => {
 
           <Route
             element={
-              webStudioAlbumPhaseOne ? (
+              webStudioAlbumPhaseOne || webStudioAlbumPhaseTwo ? (
                 <Navigate
                   to={ `${libraryRedirectPath}${routeLocation.search}${routeLocation.hash}` }
                   replace
@@ -137,8 +147,8 @@ const Home: FunctionComponent = () => {
             path="library/*"
           />
 
-          { webStudioAlbumPhaseOne && (
-            <Route element={ <Releases /> } path="releases/*" />
+          { (webStudioAlbumPhaseOne || webStudioAlbumPhaseTwo) && (
+            <Route element={ <Releases /> } path={ `${RELEASES_BASE_PATH}/*` } />
           ) }
 
           <Route element={ <Owners /> } path="collaborators/*" />

--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -5,11 +5,16 @@ import { Box, Typography } from "@mui/material";
 import { GradientDashedOutline, IconMessage, Link } from "@newm-web/elements";
 import { AddSong } from "@newm-web/assets";
 
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import SongList from "./SongList";
 import { SearchBox } from "../../../components";
 import { useGetSongCountQuery } from "../../../modules/song";
 
 const Discography: FunctionComponent = () => {
+  // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
+  const { webStudioAlbumPhaseTwo } = useFlags();
+
   const [query, setQuery] = useState("");
 
   const { data: { count: totalCountOfSongs = 0 } = {} } = useGetSongCountQuery({
@@ -33,7 +38,9 @@ const Discography: FunctionComponent = () => {
           sx={ {
             textDecoration: "none",
           } }
-          to="/home/upload-song"
+          to={
+            webStudioAlbumPhaseTwo ? "/home/releases/new" : "/home/upload-song"
+          }
         >
           <GradientDashedOutline
             sx={ {

--- a/apps/studio/src/pages/home/releases/Releases.tsx
+++ b/apps/studio/src/pages/home/releases/Releases.tsx
@@ -1,33 +1,61 @@
-import { Container } from "@mui/material";
 import { FunctionComponent } from "react";
 import { Route, Routes } from "react-router-dom";
+
+import { Container } from "@mui/material";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import EditSong from "./EditSong";
 import Discography from "./Discography";
 import ViewDetails from "./ViewDetails";
+import ReleaseDetails from "./release/ReleaseDetails";
+import TrackDetails from "./release/tracks/TrackDetails";
 import NotFoundPage from "../../NotFoundPage";
 
-const Releases: FunctionComponent = () => (
-  <Container
-    maxWidth={ false }
-    sx={ {
-      display: "flex",
-      flexDirection: "column",
-      flexGrow: 1,
-      flexWrap: "nowrap",
-      marginTop: 10.5,
-      mx: [null, null, 3],
-      pb: 8,
-      width: "auto",
-    } }
-  >
-    <Routes>
-      <Route element={ <Discography /> } path="/" />
-      <Route element={ <EditSong /> } path="edit-song/:songId*" />
-      <Route element={ <ViewDetails /> } path="view-details/:songId" />
+const Releases: FunctionComponent = () => {
+  // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
+  const { webStudioAlbumPhaseTwo } = useFlags();
 
-      <Route element={ <NotFoundPage redirectUrl="/home/releases" /> } path="*" />
-    </Routes>
-  </Container>
-);
+  return (
+    <Container
+      maxWidth={ false }
+      sx={ {
+        display: "flex",
+        flexDirection: "column",
+        flexGrow: 1,
+        flexWrap: "nowrap",
+        marginTop: 10.5,
+        mx: [null, null, 3],
+        pb: 8,
+        width: "auto",
+      } }
+    >
+      <Routes>
+        <Route element={ <Discography /> } path="/" />
+        <Route element={ <EditSong /> } path="edit-song/:songId*" />
+        <Route element={ <ViewDetails /> } path="view-details/:songId" />
+
+        { webStudioAlbumPhaseTwo && (
+          <>
+            <Route element={ <ReleaseDetails /> } path="new/*" />
+            <Route element={ <ReleaseDetails /> } path=":releaseId/*" />
+
+            <Route element={ <TrackDetails /> } path="new/track/new" />
+            <Route element={ <TrackDetails /> } path=":releaseId/track/new" />
+            <Route
+              element={ <TrackDetails /> }
+              path=":releaseId/track/:trackId"
+            />
+          </>
+        ) }
+
+        <Route
+          element={ <NotFoundPage redirectUrl="/home/releases" /> }
+          path="*"
+        />
+      </Routes>
+    </Container>
+  );
+};
 
 export default Releases;

--- a/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
@@ -1,0 +1,151 @@
+import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import DeleteIcon from "@mui/icons-material/Delete";
+import { Box, Stack, Typography } from "@mui/material";
+import {
+  Button,
+  DashedOutline,
+  HorizontalLine,
+  Link,
+  Tooltip,
+} from "@newm-web/elements";
+import { FunctionComponent } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { AddOutlined } from "@mui/icons-material";
+import ReleaseDeletionHelp from "../ReleaseDeletionHelp";
+
+/**
+ * * Shared page for creating a new release and viewing release details.
+ */
+const ReleaseDetails: FunctionComponent = () => {
+  const navigate = useNavigate();
+  const { releaseId } = useParams<"releaseId">();
+
+  // TODO: Fetch release details.
+
+  const addTrackPath = releaseId
+    ? `/home/releases/${releaseId}/track/new`
+    : "/home/releases/new/track/new";
+
+  return (
+    <>
+      <Stack alignItems="center" direction="row" gap={ 2.5 }>
+        <Button
+          color="white"
+          variant="outlined"
+          width="icon"
+          onClick={ () => navigate(-1) }
+        >
+          <ArrowBackIcon />
+        </Button>
+
+        <Typography variant="h3">
+          { /* // TODO: Update with release title. */ }
+          { releaseId ? "RELEASE DETAILS (release.title)" : "CREATE NEW RELEASE" }
+        </Typography>
+
+        { releaseId && (
+          // TODO: Update with standalone delete button component.
+          <Tooltip title={ <ReleaseDeletionHelp /> }>
+            <Stack ml="auto">
+              <Button
+                color="white"
+                disabled={ true }
+                sx={ { marginLeft: "auto" } }
+                variant="outlined"
+                width="icon"
+              >
+                <DeleteIcon fontSize="small" sx={ { color: "white" } } />
+              </Button>
+            </Stack>
+          </Tooltip>
+        ) }
+      </Stack>
+
+      <Box
+        pb={ 7 }
+        pt={ 3 }
+        sx={ {
+          display: "flex",
+          flexDirection: ["column", "column", "row"],
+          gap: 8,
+        } }
+      >
+        <Box sx={ { flex: 1, minWidth: 0 } }>
+          <Box
+            sx={ {
+              padding: 2,
+            } }
+          >
+            <Typography variant="subtitle1">
+              Release details form (placeholder)
+            </Typography>
+          </Box>
+        </Box>
+
+        <Box sx={ { flex: 1, minWidth: 0 } }>
+          <Stack gap={ 3 }>
+            <Typography variant="h4">TRACKS</Typography>
+
+            { /* // TODO: conditionally render Box with track list. */ }
+            <Box
+              sx={ {
+                padding: 2,
+              } }
+            >
+              <Typography variant="subtitle1">
+                Track list (placeholder)
+              </Typography>
+            </Box>
+
+            <Box
+              sx={ {
+                display: "flex",
+                flexDirection: ["column", "column", "row"],
+                gap: 2,
+              } }
+            >
+              <Box width="100%">
+                <Link
+                  aria-label="Add new track"
+                  sx={ {
+                    textDecoration: "none",
+                  } }
+                  to={ addTrackPath }
+                >
+                  <DashedOutline
+                    sx={ {
+                      alignItems: "center",
+                      display: "flex",
+                      flex: 1,
+                      justifyContent: "center",
+                      padding: 4,
+                    } }
+                  >
+                    <AddOutlined sx={ { marginRight: 0.5 } } /> Add new track
+                  </DashedOutline>
+                </Link>
+              </Box>
+            </Box>
+
+            <HorizontalLine />
+
+            <Box sx={ { flex: 1, minWidth: 0 } }>
+              <Button
+                // TODO: update disabled state.
+                disabled={ true }
+                variant="primary"
+                width="compact"
+                // TODO: Add logic to proceed to next step.
+                onClick={ () => null }
+              >
+                Proceed
+              </Button>
+            </Box>
+          </Stack>
+        </Box>
+      </Box>
+    </>
+  );
+};
+
+export default ReleaseDetails;

--- a/apps/studio/src/pages/home/releases/release/tracks/TrackDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/TrackDetails.tsx
@@ -1,0 +1,10 @@
+import type { FunctionComponent } from "react";
+
+/**
+ * * Shared page for creating a new track and viewing track details.
+ */
+const TrackDetails: FunctionComponent = () => {
+  return <div>TrackDetails</div>;
+};
+
+export default TrackDetails;


### PR DESCRIPTION
# Pull Request — Issue [Sub-task 1](https://projectnewm.atlassian.net/browse/STUD-552?focusedCommentId=21555) of #[STUD-552](https://projectnewm.atlassian.net/browse/STUD-552)

## Overview

> This PR scaffolds the phase-two releases flow, adds basic layout for the
> new releases/** pages, and gates new routes behind the feature flag.  
> _Context: provides the route structure and placeholder UI needed to start
> building the new release/track workflow without exposing it when the flag is off._

---

## Files Summary

> **Total Changes:** 5 files  
> _(2 added, 3 modified)_

<details>
<summary>Added (2)</summary>

- **`apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx`**
  - — Shared release page scaffold with header and two-column layout placeholders.
- **`apps/studio/src/pages/home/releases/release/tracks/TrackDetails.tsx`**
  - — Placeholder track details page for new and existing tracks.

</details>

<details>
<summary>Modified (3)</summary>

- **`apps/studio/src/pages/home/Home.tsx`**
  - — Routes updated to allow the releases entry path while phase two is enabled.
- **`apps/studio/src/pages/home/releases/Discography.tsx`**
  - — “Create New Release” CTA points to `/home/releases/new` under phase two.
- **`apps/studio/src/pages/home/releases/Releases.tsx`**
  - — Adds new release/track routes and gates them behind `webStudioAlbumPhaseTwo`.

</details>

<details>
<summary>Deleted (0)</summary>

_No deletions._

</details>

---

## Impact

- Adds a scaffolded release details page with a placeholder layout for
  release form content and tracks.
- Adds new release/track routes that are only reachable when
  `webStudioAlbumPhaseTwo` is enabled.
- Updates the releases landing CTA to use the new create flow under phase two.

---

## Testing

- Not run (UI/layout scaffolding only).

---

## Related Issues

- Closes [Sub-task 1](https://projectnewm.atlassian.net/browse/STUD-552?focusedCommentId=21555) of #[STUD-552](https://projectnewm.atlassian.net/browse/STUD-552)

---

## Dependencies

- No new dependencies.

---

## Additional Notes

- `ReleaseDetails` and `TrackDetails` are placeholders; form and track list
  logic will follow in subsequent PRs.

--END--


[STUD-552]: https://projectnewm.atlassian.net/browse/STUD-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-552]: https://projectnewm.atlassian.net/browse/STUD-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ