### PR TITLE
[STUD-571][Feature]: Update unsaved changes warning context, modal copy and styles

### DIFF
--- a/apps/studio/src/contexts/test/UnsavedChangesContext.test.tsx
+++ b/apps/studio/src/contexts/test/UnsavedChangesContext.test.tsx
@@ -78,7 +78,7 @@ describe("<UnsavedChangesProvider />", () => {
     expect(screen.getByRole("button", { name: "Discard" })).toBeInTheDocument();
   });
 
-  it("calls navigate with path when Leave is clicked after requestNavigation(path)", () => {
+  it("calls navigate with path when 'Discard' is clicked after requestNavigation(path)", () => {
     const Consumer = () => {
       const { requestNavigation } = useUnsavedChanges();
       return (
@@ -104,7 +104,7 @@ describe("<UnsavedChangesProvider />", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/home/profile");
   });
 
-  it("calls navigate(-1) when Leave is clicked after requestNavigation(null)", () => {
+  it("calls navigate(-1) when 'Discard' is clicked after requestNavigation(null)", () => {
     const Consumer = () => {
       const { requestNavigation } = useUnsavedChanges();
       return (
@@ -127,7 +127,7 @@ describe("<UnsavedChangesProvider />", () => {
     expect(mockNavigate).toHaveBeenCalledWith(-1);
   });
 
-  it("closes modal and does not call navigate when Stay is clicked", () => {
+  it("closes modal and does not call navigate when 'Keep editing' is clicked", () => {
     const Consumer = () => {
       const { requestNavigation } = useUnsavedChanges();
       return (

--- a/apps/studio/src/contexts/test/UnsavedChangesContext.test.tsx
+++ b/apps/studio/src/contexts/test/UnsavedChangesContext.test.tsx
@@ -66,14 +66,16 @@ describe("<UnsavedChangesProvider />", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: /stay/i })
+      screen.queryByRole("button", { name: /keep editing/i })
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /request nav/i }));
 
     expect(screen.getByText(UNSAVED_MESSAGE)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Stay" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Leave" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Keep editing" })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Discard" })).toBeInTheDocument();
   });
 
   it("calls navigate with path when Leave is clicked after requestNavigation(path)", () => {
@@ -96,7 +98,7 @@ describe("<UnsavedChangesProvider />", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /go to profile/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Leave" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith("/home/profile");
@@ -119,7 +121,7 @@ describe("<UnsavedChangesProvider />", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /go back/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Leave" }));
+    fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith(-1);
@@ -142,12 +144,89 @@ describe("<UnsavedChangesProvider />", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /go to wallet/i }));
-    fireEvent.click(screen.getByRole("button", { name: "Stay" }));
+    fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
 
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(
-      screen.queryByRole("button", { name: "Leave" })
+      screen.queryByRole("button", { name: "Discard" })
     ).not.toBeInTheDocument();
+  });
+
+  // eslint-disable-next-line max-len
+  it("shows default title and message from setUnsavedModalContent when requestNavigation is called without options", () => {
+    const defaultTitle = "Unsaved track";
+    const defaultMessage =
+      "You haven't added the track. If you leave, changes will be lost.";
+
+    const Consumer = () => {
+      const { requestNavigation, setUnsavedModalContent } = useUnsavedChanges();
+      return (
+        <>
+          <button
+            type="button"
+            onClick={ () =>
+              setUnsavedModalContent({
+                message: defaultMessage,
+                title: defaultTitle,
+              })
+            }
+          >
+            Set content
+          </button>
+          <button
+            type="button"
+            onClick={ () => requestNavigation("/home/releases") }
+          >
+            Request nav
+          </button>
+        </>
+      );
+    };
+
+    renderWithContext(
+      <UnsavedChangesProvider>
+        <Consumer />
+      </UnsavedChangesProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /set content/i }));
+    fireEvent.click(screen.getByRole("button", { name: /request nav/i }));
+
+    expect(screen.getByText(defaultTitle)).toBeInTheDocument();
+    expect(screen.getByText(defaultMessage)).toBeInTheDocument();
+  });
+
+  it("shows custom title and message when passed in requestNavigation options", () => {
+    const customTitle = "Unsaved release";
+    const customMessage = "If you leave, your release details will be lost.";
+
+    const Consumer = () => {
+      const { requestNavigation } = useUnsavedChanges();
+      return (
+        <button
+          type="button"
+          onClick={ () =>
+            requestNavigation("/home/releases", {
+              message: customMessage,
+              title: customTitle,
+            })
+          }
+        >
+          Request nav
+        </button>
+      );
+    };
+
+    renderWithContext(
+      <UnsavedChangesProvider>
+        <Consumer />
+      </UnsavedChangesProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /request nav/i }));
+
+    expect(screen.getByText(customTitle)).toBeInTheDocument();
+    expect(screen.getByText(customMessage)).toBeInTheDocument();
   });
 
   it("provides setHasUnsavedChanges and hasUnsavedChanges to consumers", () => {

--- a/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
+++ b/apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx
@@ -119,9 +119,16 @@ const ReleaseDetailsFormContent: FunctionComponent<ReleaseDetailsFormContentProp
         } else {
           setUnsavedModalContent(null);
         }
-
-        return () => setUnsavedModalContent(null);
       }, [dirty, setUnsavedModalContent]);
+
+      // * Reset context only on unmount; setters from context are stable.
+      useEffect(() => {
+        return () => {
+          setHasUnsavedChanges(false);
+          setUnsavedModalContent(null);
+        };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
 
       useEffect(() => {
         scrollToError(errors, isSubmitting, [

--- a/apps/studio/src/pages/home/releases/release/tracks/EditTrack.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/EditTrack.tsx
@@ -417,14 +417,7 @@ const EditTrackFormContent: FunctionComponent<EditTrackFormContentProps> = ({
           color="white"
           variant="outlined"
           width="icon"
-          onClick={ () => {
-            if (dirty) {
-              isDirtyRef.current = false;
-              requestNavigation(null);
-            } else {
-              navigate(-1);
-            }
-          } }
+          onClick={ () => (dirty ? requestNavigation(null) : navigate(-1)) }
         >
           <ArrowBackIcon sx={ { color: "white" } } />
         </Button>
@@ -506,14 +499,7 @@ const EditTrackFormContent: FunctionComponent<EditTrackFormContentProps> = ({
               <Button
                 variant="outlined"
                 width="compact"
-                onClick={ () => {
-                  if (dirty) {
-                    isDirtyRef.current = false;
-                    requestNavigation(null);
-                  } else {
-                    navigate(-1);
-                  }
-                } }
+                onClick={ () => (dirty ? requestNavigation(null) : navigate(-1)) }
               >
                 Cancel
               </Button>

--- a/apps/studio/src/pages/home/releases/release/tracks/EditTrack.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/EditTrack.tsx
@@ -73,11 +73,16 @@ const EditTrackUnsavedSync: FunctionComponent = () => {
     } else {
       setUnsavedModalContent(null);
     }
+  }, [dirty, setHasUnsavedChanges, setUnsavedModalContent]);
+
+  // * Reset context only on unmount; setters from context are stable.
+  useEffect(() => {
     return () => {
       setHasUnsavedChanges(false);
       setUnsavedModalContent(null);
     };
-  }, [dirty, setHasUnsavedChanges, setUnsavedModalContent]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 };

--- a/apps/studio/src/pages/home/releases/release/tracks/NewTrack.tsx
+++ b/apps/studio/src/pages/home/releases/release/tracks/NewTrack.tsx
@@ -62,11 +62,16 @@ const NewTrackUnsavedSync: FunctionComponent = () => {
     } else {
       setUnsavedModalContent(null);
     }
+  }, [dirty, setHasUnsavedChanges, setUnsavedModalContent]);
+
+  // * Reset context only on unmount; setters from context are stable.
+  useEffect(() => {
     return () => {
       setHasUnsavedChanges(false);
       setUnsavedModalContent(null);
     };
-  }, [dirty, setHasUnsavedChanges, setUnsavedModalContent]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 };

--- a/packages/components/src/lib/modals/UnsavedChangesModal.tsx
+++ b/packages/components/src/lib/modals/UnsavedChangesModal.tsx
@@ -37,6 +37,9 @@ export const UnsavedChangesModal: FunctionComponent<
         flex={ 1 }
         justifyContent="center"
         maxWidth={ 600 }
+        sx={ {
+          margin: "0 20px",
+        } }
       >
         <Stack
           gap={ 2 }
@@ -48,24 +51,39 @@ export const UnsavedChangesModal: FunctionComponent<
             rowGap: 1,
           } }
         >
-          <Stack gap={ 1 } textAlign="start">
-            { !!title && <Typography variant="h5">{ title }</Typography> }
-            <Typography variant="body2">{ message }</Typography>
+          <Stack gap={ 1 } mb={ 1 } textAlign="start">
+            { !!title && (
+              <Typography
+                sx={ {
+                  fontSize: 20,
+                  fontWeight: 700,
+                  textTransform: "uppercase",
+                } }
+              >
+                { title }
+              </Typography>
+            ) }
+            <Typography
+              sx={ { fontSize: 14, fontWeight: 400 } }
+              variant="subtitle1"
+            >
+              { message }
+            </Typography>
           </Stack>
 
           <HorizontalLine />
 
-          <Stack flexDirection="row" gap={ 1 } justifyContent="end" mb={ 1 } mt={ 1 }>
+          <Stack flexDirection="row" gap={ 2 } justifyContent="end" mb={ 1 } mt={ 1 }>
+            <Button variant="primary" width="compact" onClick={ onStay }>
+              Keep editing
+            </Button>
             <Button
               color="music"
               variant="secondary"
               width="compact"
-              onClick={ onStay }
+              onClick={ onLeave }
             >
-              Stay
-            </Button>
-            <Button variant="primary" width="compact" onClick={ onLeave }>
-              Leave
+              Discard
             </Button>
           </Stack>
         </Stack>

--- a/packages/components/src/lib/test/UnsavedChangesModal.test.tsx
+++ b/packages/components/src/lib/test/UnsavedChangesModal.test.tsx
@@ -76,7 +76,7 @@ describe("<UnsavedChangesModal />", () => {
       expect(screen.getByText(title)).toBeInTheDocument();
     });
 
-    it("renders Stay and Leave buttons", () => {
+    it("renders 'Keep editing' and 'Discard' buttons", () => {
       renderWithContext(
         <UnsavedChangesModal
           isOpen={ true }
@@ -93,7 +93,7 @@ describe("<UnsavedChangesModal />", () => {
       ).toBeInTheDocument();
     });
 
-    it("calls onStay when Stay button is clicked", () => {
+    it("calls onStay when 'Keep editing' button is clicked", () => {
       renderWithContext(
         <UnsavedChangesModal
           isOpen={ true }
@@ -108,7 +108,7 @@ describe("<UnsavedChangesModal />", () => {
       expect(mockOnLeave).not.toHaveBeenCalled();
     });
 
-    it("calls onLeave when Leave button is clicked", () => {
+    it("calls onLeave when 'Discard' button is clicked", () => {
       renderWithContext(
         <UnsavedChangesModal
           isOpen={ true }

--- a/packages/components/src/lib/test/UnsavedChangesModal.test.tsx
+++ b/packages/components/src/lib/test/UnsavedChangesModal.test.tsx
@@ -25,10 +25,10 @@ describe("<UnsavedChangesModal />", () => {
       );
 
       expect(
-        screen.queryByRole("button", { name: /stay/i })
+        screen.queryByRole("button", { name: /keep editing/i })
       ).not.toBeInTheDocument();
       expect(
-        screen.queryByRole("button", { name: /leave/i })
+        screen.queryByRole("button", { name: /discard/i })
       ).not.toBeInTheDocument();
     });
   });
@@ -85,8 +85,12 @@ describe("<UnsavedChangesModal />", () => {
         />
       );
 
-      expect(screen.getByRole("button", { name: "Stay" })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: "Leave" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Keep editing" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Discard" })
+      ).toBeInTheDocument();
     });
 
     it("calls onStay when Stay button is clicked", () => {
@@ -98,7 +102,7 @@ describe("<UnsavedChangesModal />", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Stay" }));
+      fireEvent.click(screen.getByRole("button", { name: "Keep editing" }));
 
       expect(mockOnStay).toHaveBeenCalledTimes(1);
       expect(mockOnLeave).not.toHaveBeenCalled();
@@ -113,7 +117,7 @@ describe("<UnsavedChangesModal />", () => {
         />
       );
 
-      fireEvent.click(screen.getByRole("button", { name: "Leave" }));
+      fireEvent.click(screen.getByRole("button", { name: "Discard" }));
 
       expect(mockOnLeave).toHaveBeenCalledTimes(1);
       expect(mockOnStay).not.toHaveBeenCalled();


### PR DESCRIPTION
# Pull Request — Issue [STUD-571](https://projectnewm.atlassian.net/browse/STUD-571)

## Overview

> This PR updates the unsaved-changes warning modal with updated copy and styles (per Figma), and wires it to the release flow so that Release Details, New Track, and Edit Track all show context-specific title and message when the user tries to leave with unsaved changes (via back, cancel, or side nav). The native browser "Leave site?" dialog is used only for tab close or refresh; leaving via the in-app modal (Discard) does not trigger the native alert.
>
> Context: STUD-571 required an unsaved changes modal with updated copy. The existing context already supported a single generic message; this change adds support for custom title and message per page, and ensures all three release/track pages register their copy and use the modal consistently, with `beforeunload` reserved for hard refresh/close.

---

## Files Summary

> **Total Changes:** 7 files.
> All files are modified; none added or deleted.

<details>
<summary>Modified (7)</summary>

- **`packages/components/src/lib/modals/UnsavedChangesModal.tsx`**
  - Updated modal copy and styles to match Figma (e.g. button labels "Keep editing" and "Discard", title/message layout). Optional `title` and `message` props already supported; styling and default copy adjusted.

- **`packages/components/src/lib/test/UnsavedChangesModal.test.tsx`**
  - Tests updated to reflect new button labels and any assertion changes for the updated modal.

- **`apps/studio/src/contexts/UnsavedChangesContext.tsx`**
  - `requestNavigation(path, options?)` now accepts optional `RequestNavigationOptions` (`title`, `message`) for one-off custom copy.
  - Added `setUnsavedModalContent(options | null)` so the active page can register default title/message used when navigation is requested without options (e.g. from SideBar). When `requestNavigation(path)` is called with one argument, the context uses this stored content; otherwise the generic message is used.
  - Exported `RequestNavigationOptions` for consumers.

- **`apps/studio/src/contexts/test/UnsavedChangesContext.test.tsx`**
  - Updated expectations to use modal button labels "Keep editing" and "Discard" instead of "Stay"/"Leave".
  - Added test that custom title and message passed in `requestNavigation(path, options)` are shown in the modal.
  - Added test that when `setUnsavedModalContent` is set and `requestNavigation(path)` is called without options, the modal shows the registered default title and message.

- **`apps/studio/src/pages/home/releases/release/ReleaseDetails.tsx`**
  - Release details already used the unsaved context; now also calls `setUnsavedModalContent(RELEASE_UNSAVED_MODAL_OPTIONS)` when the form is dirty (and clears on unmount / when not dirty). Side nav and in-page back/add-track therefore show the release-specific title and message ("Wait! Don’t lose your progress.", etc.).

- **`apps/studio/src/pages/home/releases/release/tracks/NewTrack.tsx`**
  - Wired to unsaved changes context: `NewTrackUnsavedSync` syncs Formik `dirty` to `setHasUnsavedChanges` and `setUnsavedModalContent` with new-track copy. Back and Cancel use `requestNavigation(null)` when dirty, else `navigate(-1)`. Added `beforeunload` handler (using `isDirtyRef`) so the native dialog appears only on tab close/refresh. Extracted `NewTrackFormContent` so back/cancel have access to `dirty` and `requestNavigation`.

- **`apps/studio/src/pages/home/releases/release/tracks/EditTrack.tsx`**
  - Same pattern as NewTrack: `EditTrackUnsavedSync` for dirty + edit-track modal copy; `EditTrackFormContent` with back/cancel using `requestNavigation(null)` when dirty; `beforeunload` via `isDirtyRef`. To avoid the native dialog when the user clicks Discard in the modal, `isDirtyRef.current` is set to `false` before calling `requestNavigation(null)` when opening the modal (so when the context calls `navigate(-1)`, `beforeunload` does not show the native alert). If the user clicks Stay, the next render restores `isDirtyRef.current = dirty`.

</details>

---

## Impact

- **UX:** Users see page-specific unsaved-changes copy (release vs new track vs edit track) when leaving via back, cancel, or side nav, and a single, consistent modal with updated Figma copy and styles.
- **Behavior:** Native "Leave site?" dialog is only shown on tab close or refresh when there are unsaved changes; choosing "Discard" in the in-app modal no longer triggers the native alert (fix applied in EditTrack; ReleaseDetails and NewTrack were already fine).
- **Compatibility:** No API changes to the public surface of the context beyond the new optional `options` argument and `setUnsavedModalContent`; existing callers (e.g. SideBar) that call `requestNavigation(path)` with one argument continue to work and now see the default content set by the current page when applicable.
- **Tests:** UnsavedChangesContext and UnsavedChangesModal tests updated and extended for new behavior and copy.

---

## Testing

- **Unit:** `UnsavedChangesContext` and `UnsavedChangesModal` test suites run and pass (button labels, custom title/message via options, default content via `setUnsavedModalContent`).
- **Commands:**
  - `npx nx test studio --testPathPattern="UnsavedChangesContext"`,
  - `npx nx test components --testPathPattern="UnsavedChangesModal"`.
- Verify all studio and components tests pass:
  - `npx nx test studio`
  - `npx nx test components`

- **Manual:** On Release Details, New Track, and Edit Track: (1) make form dirty, (2) click back or cancel → modal with page-specific copy appears; (3) click side nav link → same modal; (4) click "Discard" → navigation occurs without native dialog; (5) with dirty form, close tab or refresh → native "Leave site?" appears. Confirm "Keep editing" keeps user on the page and "Discard" navigates as expected.

---

## Related Issues

- Closes [STUD-571](https://projectnewm.atlassian.net/browse/STUD-571) (Implement unsaved changes warning modal — update copy and styles)

---

## Dependencies

- No new dependencies.

---

## Demo

https://github.com/user-attachments/assets/09bc0db3-b97e-4a3b-932c-1f9747971b49

---

## Additional Notes

- EditTrack clears `isDirtyRef` before opening the modal so that programmatic `navigate(-1)` from the context does not trigger the native dialog; ReleaseDetails and NewTrack did not require this, likely due to route/history depth. No context changes were required for this fix.
- All three pages (ReleaseDetails, NewTrack, EditTrack) now follow the same pattern: sync dirty state and page-specific modal content, use `requestNavigation` for back/cancel when dirty, and use `beforeunload` only for tab close/refresh.


[STUD-571]: https://projectnewm.atlassian.net/browse/STUD-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-571]: https://projectnewm.atlassian.net/browse/STUD-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ