### PR TITLE
[STUD-575][Enhancement]: Implement general service disruption banner across NEWM Studio site

### DIFF
--- a/apps/studio/src/App.tsx
+++ b/apps/studio/src/App.tsx
@@ -1,15 +1,18 @@
-import { CssBaseline } from "@mui/material";
-import { ThemeProvider } from "@mui/material/styles";
 import { Provider } from "react-redux";
 import { Navigate, Route, Routes } from "react-router-dom";
-import theme from "@newm-web/theme";
 import { PersistGate } from "redux-persist/integration/react";
 import { GoogleOAuthProvider } from "@react-oauth/google";
+
+import { CssBaseline } from "@mui/material";
+import { ThemeProvider } from "@mui/material/styles";
+
+import theme from "@newm-web/theme";
 import {
   GOOGLE_CLIENT_ID,
   REFERRALHERO_ARTIST_REFERRAL_CAMPAIGN_UUID,
 } from "@newm-web/env";
 import { Maintenance, UnsupportedBrowserBanner } from "@newm-web/components";
+
 import {
   Background,
   ConnectWalletModal,
@@ -17,6 +20,7 @@ import {
   IdenfyModal,
   IdenfyPingUserStatus,
   IdenfySuccessSession,
+  InfoBanner,
   InvitesModal,
   PingEarningsInProgressWrapper,
   PingSaleEnd,
@@ -79,6 +83,8 @@ const App = () => {
               <UnsupportedBrowserBanner />
               <LDUserUpdater />
               <ScrollToTop />
+
+              <InfoBanner />
 
               <Background>
                 <BrowserRouter history={ history }>

--- a/apps/studio/src/common/constants.ts
+++ b/apps/studio/src/common/constants.ts
@@ -9,6 +9,7 @@ export const NEWM_SUPPORT_LINK =
 export const NEWM_CLICKUP_FORM_URL =
   "https://projectnewm.atlassian.net/servicedesk/customer/portal/1";
 export const NEWM_IO_URL = "https://newm.io/";
+export const NEWM_STUDIO_OFFICIAL_STATEMENT_URL = `${NEWM_IO_URL}sunset/`;
 export const NEWM_STUDIO_DISCORD_URL =
   "https://discord.com/channels/931903540056694856/1153293933468713041";
 export const NEWM_STUDIO_FAQ_URL = "https://newm.io/artist-faq";

--- a/apps/studio/src/common/hooks.ts
+++ b/apps/studio/src/common/hooks.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
+import { useMediaQuery, useTheme } from "@mui/material";
 import { selectSession } from "../modules/session";
 import type { AppDispatch, RootState } from "../store";
 
@@ -34,4 +35,12 @@ export const useAuthenticatedRedirect = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoggedIn]);
+};
+
+export const useBreakpoint = () => {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
+  const isMobile = !isDesktop;
+
+  return { isDesktop, isMobile };
 };

--- a/apps/studio/src/common/hooks.ts
+++ b/apps/studio/src/common/hooks.ts
@@ -1,7 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
+
 import { useMediaQuery, useTheme } from "@mui/material";
+
 import { selectSession } from "../modules/session";
 import type { AppDispatch, RootState } from "../store";
 
@@ -42,5 +44,5 @@ export const useBreakpoint = () => {
   const isDesktop = useMediaQuery(theme.breakpoints.up("md"));
   const isMobile = !isDesktop;
 
-  return { isDesktop, isMobile };
+  return useMemo(() => ({ isDesktop, isMobile }), [isDesktop, isMobile]);
 };

--- a/apps/studio/src/components/Background.tsx
+++ b/apps/studio/src/components/Background.tsx
@@ -1,9 +1,12 @@
 /**
- * Fixed position background image with darkened overlay.
+ * * Fixed position background image with darkened overlay.
  */
 
-import { styled } from "@mui/material/styles";
 import { ReactNode } from "react";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
+import { styled } from "@mui/material/styles";
 
 interface BackgroundProps {
   children: ReactNode;
@@ -21,20 +24,37 @@ const BackgroundImage = styled("div")({
   width: "100%",
 });
 
-const BackgroundOverlay = styled("div")({
-  backgroundColor: "rgba(0, 0, 0, 0.25)",
-  bottom: 0,
-  display: "flex",
-  left: 0,
-  position: "absolute",
-  right: 0,
-  top: 0,
-});
-
-const Background = ({ children }: BackgroundProps) => (
-  <BackgroundImage>
-    <BackgroundOverlay>{ children }</BackgroundOverlay>
-  </BackgroundImage>
+const BackgroundOverlay = styled("div")<{ applyOffset?: boolean }>(
+  ({ theme, applyOffset }) => ({
+    backgroundColor: "rgba(0, 0, 0, 0.25)",
+    bottom: 0,
+    display: "flex",
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+    // TODO(webStudioDisableDistributionAndSales): Remove the below breakpoint logic once the feature flag is removed.
+    ...(applyOffset && {
+      [theme.breakpoints.down("xl")]: {
+        [theme.breakpoints.up(960)]: {
+          top: theme.spacing(2), // * 16px with default 8px spacing.
+        },
+      },
+    }),
+  })
 );
+
+const Background = ({ children }: BackgroundProps) => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+  const applyOffset = webStudioDisableDistributionAndSales;
+
+  return (
+    <BackgroundImage>
+      <BackgroundOverlay applyOffset={ applyOffset }>
+        { children }
+      </BackgroundOverlay>
+    </BackgroundImage>
+  );
+};
 
 export default Background;

--- a/apps/studio/src/components/Background.tsx
+++ b/apps/studio/src/components/Background.tsx
@@ -7,6 +7,7 @@ import { ReactNode } from "react";
 import { useFlags } from "launchdarkly-react-client-sdk";
 
 import { styled } from "@mui/material/styles";
+import { useBrowserSupport } from "@newm-web/utils";
 
 interface BackgroundProps {
   children: ReactNode;
@@ -46,7 +47,9 @@ const BackgroundOverlay = styled("div")<{ applyOffset?: boolean }>(
 
 const Background = ({ children }: BackgroundProps) => {
   const { webStudioDisableDistributionAndSales } = useFlags();
-  const applyOffset = webStudioDisableDistributionAndSales;
+  const { isFullSupport } = useBrowserSupport();
+
+  const applyOffset = webStudioDisableDistributionAndSales && isFullSupport;
 
   return (
     <BackgroundImage>

--- a/apps/studio/src/components/InfoBanner.tsx
+++ b/apps/studio/src/components/InfoBanner.tsx
@@ -1,0 +1,50 @@
+import { FunctionComponent } from "react";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
+import { Link, useTheme } from "@mui/material";
+
+import { Banner } from "@newm-web/components";
+
+import { NEWM_IO_URL, useBreakpoint } from "../common";
+
+const InfoBanner: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
+  const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
+
+  if (!webStudioDisableDistributionAndSales) {
+    return null;
+  }
+
+  return (
+    <Banner
+      background={ theme.gradients.company }
+      fixed={ isDesktop }
+      title={
+        <>
+          NEWM Studio distribution and Stream Token sales have been
+          discontinued. Please read our team&apos;s&nbsp;
+          <Link
+            href={ NEWM_IO_URL }
+            rel="noopener noreferrer"
+            sx={ {
+              color: theme.colors.white,
+              fontWeight: 600,
+              textDecoration: "underline",
+            } }
+            target="_blank"
+          >
+            official statement
+          </Link>
+          &nbsp;for next steps regarding your releases.
+        </>
+      }
+      titleSx={ { fontWeight: 100 } }
+      fullWidth
+    />
+  );
+};
+
+export default InfoBanner;

--- a/apps/studio/src/components/InfoBanner.tsx
+++ b/apps/studio/src/components/InfoBanner.tsx
@@ -2,11 +2,12 @@ import { FunctionComponent } from "react";
 
 import { useFlags } from "launchdarkly-react-client-sdk";
 
-import { Link, useTheme } from "@mui/material";
+import { useTheme } from "@mui/material";
 
 import { Banner } from "@newm-web/components";
 
-import { NEWM_IO_URL, useBreakpoint } from "../common";
+import OfficialStatementCTA from "./OfficialStatementCTA";
+import { useBreakpoint } from "../common";
 
 const InfoBanner: FunctionComponent = () => {
   const { webStudioDisableDistributionAndSales } = useFlags();
@@ -22,25 +23,7 @@ const InfoBanner: FunctionComponent = () => {
     <Banner
       background={ theme.gradients.company }
       fixed={ isDesktop }
-      title={
-        <>
-          NEWM Studio distribution and Stream Token sales have been
-          discontinued. Please read our team&apos;s&nbsp;
-          <Link
-            href={ NEWM_IO_URL }
-            rel="noopener noreferrer"
-            sx={ {
-              color: theme.colors.white,
-              fontWeight: 600,
-              textDecoration: "underline",
-            } }
-            target="_blank"
-          >
-            official statement
-          </Link>
-          &nbsp;for next steps regarding your releases.
-        </>
-      }
+      title={ <OfficialStatementCTA /> }
       titleSx={ { fontWeight: 100 } }
       fullWidth
     />

--- a/apps/studio/src/components/OfficialStatementCTA.tsx
+++ b/apps/studio/src/components/OfficialStatementCTA.tsx
@@ -1,0 +1,40 @@
+import { FunctionComponent, ReactNode } from "react";
+
+import { Link, useTheme } from "@mui/material";
+
+import { NEWM_IO_URL } from "../common";
+
+interface OfficialStatementCTAProps {
+  readonly children?: ReactNode;
+  readonly href?: string;
+  readonly linkText?: string;
+}
+
+const OfficialStatementCTA: FunctionComponent<OfficialStatementCTAProps> = ({
+  href = NEWM_IO_URL,
+  linkText = "official statement",
+}) => {
+  const theme = useTheme();
+
+  return (
+    <>
+      NEWM Studio distribution and Stream Token sales have been discontinued.
+      Please read our team&apos;s&nbsp;
+      <Link
+        href={ href }
+        rel="noopener noreferrer"
+        sx={ {
+          color: theme.colors.white,
+          fontWeight: 600,
+          textDecoration: "underline",
+        } }
+        target="_blank"
+      >
+        { linkText }
+      </Link>
+      &nbsp;for next steps regarding your releases.
+    </>
+  );
+};
+
+export default OfficialStatementCTA;

--- a/apps/studio/src/components/OfficialStatementCTA.tsx
+++ b/apps/studio/src/components/OfficialStatementCTA.tsx
@@ -2,9 +2,7 @@ import { FunctionComponent, ReactNode } from "react";
 
 import { Link, useTheme } from "@mui/material";
 
-import { NEWM_IO_URL } from "../common";
-
-const ANNOUNCEMENT_URL = `${NEWM_IO_URL}sunset/`;
+import { NEWM_STUDIO_OFFICIAL_STATEMENT_URL } from "../common";
 
 interface OfficialStatementCTAProps {
   readonly children?: ReactNode;
@@ -13,7 +11,7 @@ interface OfficialStatementCTAProps {
 }
 
 const OfficialStatementCTA: FunctionComponent<OfficialStatementCTAProps> = ({
-  href = ANNOUNCEMENT_URL,
+  href = NEWM_STUDIO_OFFICIAL_STATEMENT_URL,
   linkText = "official statement",
 }) => {
   const theme = useTheme();

--- a/apps/studio/src/components/OfficialStatementCTA.tsx
+++ b/apps/studio/src/components/OfficialStatementCTA.tsx
@@ -11,7 +11,7 @@ interface OfficialStatementCTAProps {
 }
 
 const OfficialStatementCTA: FunctionComponent<OfficialStatementCTAProps> = ({
-  href = NEWM_IO_URL,
+  href = `${NEWM_IO_URL}sunset/`,
   linkText = "official statement",
 }) => {
   const theme = useTheme();

--- a/apps/studio/src/components/OfficialStatementCTA.tsx
+++ b/apps/studio/src/components/OfficialStatementCTA.tsx
@@ -4,6 +4,8 @@ import { Link, useTheme } from "@mui/material";
 
 import { NEWM_IO_URL } from "../common";
 
+const ANNOUNCEMENT_URL = `${NEWM_IO_URL}sunset/`;
+
 interface OfficialStatementCTAProps {
   readonly children?: ReactNode;
   readonly href?: string;
@@ -11,7 +13,7 @@ interface OfficialStatementCTAProps {
 }
 
 const OfficialStatementCTA: FunctionComponent<OfficialStatementCTAProps> = ({
-  href = `${NEWM_IO_URL}sunset/`,
+  href = ANNOUNCEMENT_URL,
   linkText = "official statement",
 }) => {
   const theme = useTheme();

--- a/apps/studio/src/components/OfficialStatementCTA.tsx
+++ b/apps/studio/src/components/OfficialStatementCTA.tsx
@@ -18,7 +18,7 @@ const OfficialStatementCTA: FunctionComponent<OfficialStatementCTAProps> = ({
 
   return (
     <>
-      NEWM Studio distribution and Stream Token sales have been discontinued.
+      NEWM Studio is stopping distribution services and Stream Token sales.
       Please read our team&apos;s&nbsp;
       <Link
         href={ href }
@@ -32,7 +32,8 @@ const OfficialStatementCTA: FunctionComponent<OfficialStatementCTAProps> = ({
       >
         { linkText }
       </Link>
-      &nbsp;for next steps regarding your releases.
+      &nbsp;for more information, key dates and instructions on how to migrate
+      your catalog.
     </>
   );
 };

--- a/apps/studio/src/components/index.ts
+++ b/apps/studio/src/components/index.ts
@@ -43,3 +43,4 @@ export { default as Toast } from "./Toast";
 export { default as UpdateWalletAddressModal } from "./UpdateWalletAddressModal";
 export { default as ViewPDF } from "./ViewPDF";
 export { default as WalletEnvMismatchModal } from "./WalletEnvMismatchModal";
+export { default as InfoBanner } from "./InfoBanner";

--- a/apps/studio/src/pages/forgotPassword/ForgotPassword.tsx
+++ b/apps/studio/src/pages/forgotPassword/ForgotPassword.tsx
@@ -1,24 +1,38 @@
-import * as Yup from "yup";
-import { Box, Container } from "@mui/material";
 import { FunctionComponent, useCallback, useMemo } from "react";
+import { useLocation } from "react-router-dom";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import { FormikHelpers, FormikValues } from "formik";
+import * as Yup from "yup";
+
+import { Box, Container } from "@mui/material";
+
 import theme from "@newm-web/theme";
 import { WizardForm } from "@newm-web/elements";
-import { useLocation } from "react-router-dom";
 import { removeTrailingSlash } from "@newm-web/utils";
+
 import InitiateReset from "./InitiateReset";
 import VerifyEmail from "./VerifyEmail";
 import ResetPassword from "./ResetPassword";
 import NotFoundPage from "../NotFoundPage";
 import { resetPassword, sendVerificationEmail } from "../../modules/session";
-import { commonYupValidation, useAppDispatch } from "../../common";
+import {
+  commonYupValidation,
+  useAppDispatch,
+  useBreakpoint,
+} from "../../common";
 import { ResponsiveNEWMLogo } from "../../components";
 
 const rootPath = "forgot-password";
 
 const ForgotPassword: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const dispatch = useAppDispatch();
   const currentPathLocation = useLocation();
+
+  const { isDesktop } = useBreakpoint();
 
   const initialValues = {
     authCode: "",
@@ -105,6 +119,7 @@ const ForgotPassword: FunctionComponent = () => {
         backgroundColor: theme.colors.black,
         display: "flex",
         flexDirection: "column",
+        marginTop: webStudioDisableDistributionAndSales && isDesktop ? 5 : 0,
         pt: 7.5,
         px: 2,
       } }

--- a/apps/studio/src/pages/home/Home.tsx
+++ b/apps/studio/src/pages/home/Home.tsx
@@ -42,6 +42,7 @@ const Home: FunctionComponent = () => {
     webStudioAlbumPhaseOne,
     webStudioAlbumPhaseTwo,
     webStudioArtistReferralCampaign,
+    webStudioDisableDistributionAndSales,
   } = useFlags();
 
   const routeLocation = useLocation();
@@ -115,7 +116,11 @@ const Home: FunctionComponent = () => {
             width: { sm: `calc(100% - ${drawerWidth}px)` },
           } }
         >
-          <Box left="2rem" position="absolute" top="2rem">
+          <Box
+            left="2rem"
+            position="absolute"
+            top={ webStudioDisableDistributionAndSales ? 20 : 32 }
+          >
             <IconButton onClick={ () => setMobileOpen(true) }>
               <MenuIcon sx={ { color: "white" } } />
             </IconButton>

--- a/apps/studio/src/pages/home/Home.tsx
+++ b/apps/studio/src/pages/home/Home.tsx
@@ -25,7 +25,7 @@ import Profile from "./profile/Profile";
 import Settings from "./settings/Settings";
 import { emptyProfile, useGetProfileQuery } from "../../modules/session";
 import { useGetStudioClientConfigQuery } from "../../modules/content";
-import { identifyReferralHeroUser } from "../../common";
+import { identifyReferralHeroUser, useBreakpoint } from "../../common";
 import NotFoundPage from "../NotFoundPage";
 import { UnsavedChangesProvider } from "../../contexts/UnsavedChangesContext";
 
@@ -33,7 +33,10 @@ const RELEASES_BASE_PATH = "releases";
 
 const Home: FunctionComponent = () => {
   const drawerWidth = 230;
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
+
   const navigate = useNavigate();
 
   // TODO(webStudioAlbumPhaseOne): Remove flag once flag is retired.
@@ -119,7 +122,7 @@ const Home: FunctionComponent = () => {
           <Box
             left="2rem"
             position="absolute"
-            top={ webStudioDisableDistributionAndSales ? 20 : 32 }
+            top={ webStudioDisableDistributionAndSales && !isDesktop ? 20 : 32 }
           >
             <IconButton onClick={ () => setMobileOpen(true) }>
               <MenuIcon sx={ { color: "white" } } />

--- a/apps/studio/src/pages/home/SideBar.tsx
+++ b/apps/studio/src/pages/home/SideBar.tsx
@@ -152,7 +152,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
         flexDirection: "column",
         height: "100%",
         justifyContent: "space-between",
-        marginTop: webStudioDisableDistributionAndSales && isDesktop ? 5 : 0,
+        marginTop: webStudioDisableDistributionAndSales && isDesktop ? 8 : 0,
         minWidth: theme.spacing(28.75),
         overflowY: "auto",
         padding: 1.25,

--- a/apps/studio/src/pages/home/SideBar.tsx
+++ b/apps/studio/src/pages/home/SideBar.tsx
@@ -15,7 +15,6 @@ import {
   Link,
   Stack,
   Typography,
-  useTheme,
 } from "@mui/material";
 import {
   PeopleAlt as CollaboratorsIcon,
@@ -72,7 +71,6 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
 
   const { hasUnsavedChanges, requestNavigation } = useUnsavedChanges();
 
-  const theme = useTheme();
   const { isDesktop } = useBreakpoint();
 
   const handleInternalNavClick = useCallback(

--- a/apps/studio/src/pages/home/SideBar.tsx
+++ b/apps/studio/src/pages/home/SideBar.tsx
@@ -5,6 +5,9 @@ import {
   useRef,
   useState,
 } from "react";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import {
   Box,
   Drawer,
@@ -14,12 +17,6 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import {
-  ProfileImage,
-  SideBarHeader,
-  SideBarNavLink,
-} from "@newm-web/elements";
-import { DiscordLogo, NEWMLogo } from "@newm-web/assets";
 import {
   PeopleAlt as CollaboratorsIcon,
   LiveHelp as FaqIcon,
@@ -31,19 +28,27 @@ import {
   FileUploadOutlined as UploadIcon,
   AccountBalanceWalletRounded as WalletIcon,
 } from "@mui/icons-material";
+
+import {
+  ProfileImage,
+  SideBarHeader,
+  SideBarNavLink,
+} from "@newm-web/elements";
+import { DiscordLogo, NEWMLogo } from "@newm-web/assets";
 import {
   LocalStorage,
   resizeCloudinaryImage,
   useWindowDimensions,
 } from "@newm-web/utils";
 import theme from "@newm-web/theme";
-import { useFlags } from "launchdarkly-react-client-sdk";
 import { LocalStorageKey } from "@newm-web/types";
+
 import {
   NEWM_CLICKUP_FORM_URL,
   NEWM_IO_URL,
   NEWM_STUDIO_DISCORD_URL,
   NEWM_STUDIO_FAQ_URL,
+  useBreakpoint,
 } from "../../common";
 import { useUnsavedChanges } from "../../contexts/UnsavedChangesContext";
 import { emptyProfile, useGetProfileQuery } from "../../modules/session";
@@ -59,11 +64,16 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
   setMobileOpen,
 }: SideBarProps) => {
   // TODO(webStudioAlbumPhaseOne): Remove flag once flag is retired.
-  const { webStudioAlbumPhaseOne, webStudioArtistReferralCampaign } =
-    useFlags();
+  const {
+    webStudioAlbumPhaseOne,
+    webStudioArtistReferralCampaign,
+    webStudioDisableDistributionAndSales,
+  } = useFlags();
 
   const { hasUnsavedChanges, requestNavigation } = useUnsavedChanges();
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
 
   const handleInternalNavClick = useCallback(
     (path: string) => (event?: React.MouseEvent) => {
@@ -144,6 +154,7 @@ export const SideBar: FunctionComponent<SideBarProps> = ({
         flexDirection: "column",
         height: "100%",
         justifyContent: "space-between",
+        marginTop: webStudioDisableDistributionAndSales && isDesktop ? 5 : 0,
         minWidth: theme.spacing(28.75),
         overflowY: "auto",
         padding: 1.25,

--- a/apps/studio/src/pages/login/Login.tsx
+++ b/apps/studio/src/pages/login/Login.tsx
@@ -1,3 +1,5 @@
+import { FunctionComponent, MouseEventHandler, useState } from "react";
+
 import { Box, Stack, Typography, useTheme } from "@mui/material";
 import {
   Button,
@@ -6,16 +8,25 @@ import {
   PasswordInputField,
   TextInputField,
 } from "@newm-web/elements";
-import { FunctionComponent, MouseEventHandler, useState } from "react";
+
 import { Form, Formik, FormikValues } from "formik";
 import * as Yup from "yup";
-import { commonYupValidation, useAuthenticatedRedirect } from "../../common";
+import { useFlags } from "launchdarkly-react-client-sdk";
+
+import {
+  commonYupValidation,
+  useAuthenticatedRedirect,
+  useBreakpoint,
+} from "../../common";
 import { history } from "../../common/history";
 import { AppleLogin, GoogleLogin, ResponsiveNEWMLogo } from "../../components";
 import { useLoginThunk } from "../../modules/session";
 
 const Login: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
 
   const [login, { isLoading }] = useLoginThunk();
   const [maskPassword, setMaskPassword] = useState(true);
@@ -53,6 +64,7 @@ const Login: FunctionComponent = () => {
         backgroundColor: theme.colors.black,
         display: "flex",
         flexDirection: "column",
+        marginTop: webStudioDisableDistributionAndSales && isDesktop ? 5 : 0,
         width: "100%",
       } }
     >

--- a/apps/studio/src/pages/signUp/SignUp.tsx
+++ b/apps/studio/src/pages/signUp/SignUp.tsx
@@ -1,14 +1,23 @@
-import * as Yup from "yup";
-import { Box, useTheme } from "@mui/material";
-import { FormikValues } from "formik";
 import { FunctionComponent, useCallback, useMemo } from "react";
-import { WizardForm } from "@newm-web/elements";
 import { useLocation } from "react-router-dom";
+
+import { Box, useTheme } from "@mui/material";
+
+import * as Yup from "yup";
+import { FormikValues } from "formik";
+import { useFlags } from "launchdarkly-react-client-sdk";
+
+import { WizardForm } from "@newm-web/elements";
 import { removeTrailingSlash } from "@newm-web/utils";
+
 import Verification from "./Verification";
 import Welcome from "./Welcome";
 import NotFoundPage from "../NotFoundPage";
-import { commonYupValidation, useAppDispatch } from "../../common";
+import {
+  commonYupValidation,
+  useAppDispatch,
+  useBreakpoint,
+} from "../../common";
 import { createAccount, sendVerificationEmail } from "../../modules/session";
 
 const rootPath = "sign-up";
@@ -22,7 +31,11 @@ interface AccountValues {
 }
 
 const SignUp: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
+
   const dispatch = useAppDispatch();
   const currentPathLocation = useLocation();
 
@@ -114,6 +127,7 @@ const SignUp: FunctionComponent = () => {
         display: "flex",
         flex: 1,
         justifyContent: "center",
+        marginTop: webStudioDisableDistributionAndSales && isDesktop ? 2 : 0,
         maxWidth: "100%",
         pt: 5,
         px: 2,

--- a/apps/studio/src/pages/signUp/Verification.tsx
+++ b/apps/studio/src/pages/signUp/Verification.tsx
@@ -1,14 +1,25 @@
 import { FunctionComponent, useState } from "react";
-import { Button, GradientTypography, TextInputField } from "@newm-web/elements";
-import { FormikValues, useFormikContext } from "formik";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import { Box, Stack, Typography, useTheme } from "@mui/material";
+
+import { FormikValues, useFormikContext } from "formik";
+
+import { Button, GradientTypography, TextInputField } from "@newm-web/elements";
+
 import { ResponsiveNEWMLogo } from "../../components";
 import { sendVerificationEmail } from "../../modules/session";
-import { useAppDispatch } from "../../common";
+import { useAppDispatch, useBreakpoint } from "../../common";
 
 const Verification: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const dispatch = useAppDispatch();
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
+
   const [showResendLink, setShowResendLink] = useState(true);
   const { values } = useFormikContext<FormikValues>();
 
@@ -31,7 +42,12 @@ const Verification: FunctionComponent = () => {
         justifyContent: "space-between",
       } }
     >
-      <Box alignItems="center" display="flex" flexDirection="column">
+      <Box
+        alignItems="center"
+        display="flex"
+        flexDirection="column"
+        marginTop={ webStudioDisableDistributionAndSales && isDesktop ? 4 : 0 }
+      >
         <Box mb={ 4 }>
           <ResponsiveNEWMLogo />
         </Box>

--- a/apps/studio/src/pages/signUp/Welcome.tsx
+++ b/apps/studio/src/pages/signUp/Welcome.tsx
@@ -1,18 +1,28 @@
+import { FunctionComponent, useState } from "react";
+
+import { FormikValues, useFormikContext } from "formik";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import { Box, Stack, Typography, useTheme } from "@mui/material";
+
 import {
   Button,
   HorizontalLine,
   PasswordInputField,
   TextInputField,
 } from "@newm-web/elements";
-import { FunctionComponent, useState } from "react";
-import { FormikValues, useFormikContext } from "formik";
-import { useAuthenticatedRedirect } from "../../common";
+
+import { useAuthenticatedRedirect, useBreakpoint } from "../../common";
 import { history } from "../../common/history";
 import { AppleLogin, GoogleLogin, ResponsiveNEWMLogo } from "../../components";
 
 const SignUp: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
+
   const { values } = useFormikContext();
   const { referrer, newPassword, confirmPassword } = values as FormikValues;
   const [maskPassword, setMaskPassword] = useState(true);
@@ -25,7 +35,12 @@ const SignUp: FunctionComponent = () => {
   useAuthenticatedRedirect();
 
   return (
-    <Box alignItems="center" display="flex" flexDirection="column">
+    <Box
+      alignItems="center"
+      display="flex"
+      flexDirection="column"
+      mt={ webStudioDisableDistributionAndSales && isDesktop ? 3 : 0 }
+    >
       <Stack sx={ { alignItems: "center", gap: 1, width: "100%" } }>
         <Button
           color="music"

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,4 +1,5 @@
 export { default as Alert } from "./lib/Alert";
+export { default as Banner } from "./lib/Banner";
 export * from "./lib/ActionMenu";
 export { default as ActionMenu } from "./lib/ActionMenu";
 export * from "./lib/ActionMenuTrigger";

--- a/packages/components/src/lib/Banner.tsx
+++ b/packages/components/src/lib/Banner.tsx
@@ -1,0 +1,72 @@
+import type { FunctionComponent, ReactNode } from "react";
+
+import {
+  Box,
+  Stack,
+  type SxProps,
+  type Theme,
+  Typography,
+  useTheme,
+} from "@mui/material";
+
+interface BannerProps {
+  readonly background?: string;
+  readonly description?: string | ReactNode;
+  readonly fixed?: boolean;
+  readonly fullWidth?: boolean;
+  readonly sx?: SxProps<Theme>;
+  readonly textAlign?: "center" | "left" | "right";
+  readonly textColor?: string;
+  readonly title: string | ReactNode;
+  readonly titleSx?: SxProps<Theme>;
+}
+
+const Banner: FunctionComponent<BannerProps> = ({
+  title,
+  titleSx,
+  description,
+  background,
+  textColor,
+  fixed = false,
+  fullWidth = false,
+  textAlign = "center",
+  sx,
+}) => {
+  const theme = useTheme();
+
+  const bg = background ?? theme.gradients.music;
+  const color = textColor ?? theme.colors.white;
+
+  return (
+    <Box
+      data-testid="banner"
+      sx={ {
+        background: bg,
+        color: color,
+        paddingX: 3,
+        paddingY: { md: 2, xs: 1 },
+        position: fixed ? "fixed" : undefined,
+        top: fixed ? 0 : undefined,
+        width: fullWidth ? "100%" : undefined,
+        // * 1400 is our packages/components/**/Alert.tsx
+        zIndex: fixed ? 1300 : undefined,
+        ...sx,
+      } }
+      textAlign={ textAlign }
+    >
+      <Stack spacing={ description ? 0.5 : 0 }>
+        <Typography sx={ { ...titleSx } } variant="h4">
+          { title }
+        </Typography>
+
+        { description && (
+          <Typography fontWeight={ 400 } variant="body1">
+            { description }
+          </Typography>
+        ) }
+      </Stack>
+    </Box>
+  );
+};
+
+export default Banner;

--- a/packages/components/src/lib/Banner.tsx
+++ b/packages/components/src/lib/Banner.tsx
@@ -50,8 +50,7 @@ const Banner: FunctionComponent<BannerProps> = ({
             ...(fixed && {
               position: "fixed",
               top: 0,
-              // * Place Banner just below Snackbars (see packages/components/**/Alert.tsx)
-              zIndex: theme.zIndex.snackbar - 1,
+              zIndex: theme.zIndex.modal,
             }),
             ...(fullWidth && {
               width: "100%",

--- a/packages/components/src/lib/Banner.tsx
+++ b/packages/components/src/lib/Banner.tsx
@@ -40,22 +40,30 @@ const Banner: FunctionComponent<BannerProps> = ({
   return (
     <Box
       data-testid="banner"
-      sx={ {
-        background: bg,
-        color: color,
-        paddingX: 3,
-        paddingY: { md: 2, xs: 1 },
-        position: fixed ? "fixed" : undefined,
-        top: fixed ? 0 : undefined,
-        width: fullWidth ? "100%" : undefined,
-        // * Place Banner just below Snackbars (see packages/components/**/Alert.tsx)
-        zIndex: fixed ? theme.zIndex.snackbar - 1 : undefined,
-        ...sx,
-      } }
+      sx={
+        [
+          {
+            background: bg,
+            color: color,
+            paddingX: 3,
+            paddingY: { md: 2, xs: 1 },
+            ...(fixed && {
+              position: "fixed",
+              top: 0,
+              // * Place Banner just below Snackbars (see packages/components/**/Alert.tsx)
+              zIndex: theme.zIndex.snackbar - 1,
+            }),
+            ...(fullWidth && {
+              width: "100%",
+            }),
+          },
+          sx,
+        ] as SxProps<Theme>
+      }
       textAlign={ textAlign }
     >
       <Stack spacing={ description ? 0.5 : 0 }>
-        <Typography sx={ { ...titleSx } } variant="h4">
+        <Typography sx={ titleSx } variant="h4">
           { title }
         </Typography>
 

--- a/packages/components/src/lib/Banner.tsx
+++ b/packages/components/src/lib/Banner.tsx
@@ -48,8 +48,8 @@ const Banner: FunctionComponent<BannerProps> = ({
         position: fixed ? "fixed" : undefined,
         top: fixed ? 0 : undefined,
         width: fullWidth ? "100%" : undefined,
-        // * 1400 is our packages/components/**/Alert.tsx
-        zIndex: fixed ? 1300 : undefined,
+        // * Place Banner just below Snackbars (see packages/components/**/Alert.tsx)
+        zIndex: fixed ? theme.zIndex.snackbar - 1 : undefined,
         ...sx,
       } }
       textAlign={ textAlign }

--- a/packages/components/src/lib/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/lib/UnsupportedBrowserBanner.tsx
@@ -1,17 +1,16 @@
-import { Container, Stack, Typography, useTheme } from "@mui/material";
-import { Alert, Button } from "@newm-web/elements";
-import { browserName } from "react-device-detect";
 import { FunctionComponent, useEffect, useState } from "react";
+
+import { Container, Stack, Typography, useTheme } from "@mui/material";
+
+import { Alert, Button } from "@newm-web/elements";
+import { useBrowserSupport } from "@newm-web/utils";
 
 const UnsupportedBrowserBanner: FunctionComponent = () => {
   const theme = useTheme();
 
   const [isVisible, setIsVisible] = useState(false);
 
-  const fullSupportBrowsers = ["Chrome", "Brave", "Edge"];
-  const limitedSupportBrowsers = ["Firefox"];
-  const isFullSupport = fullSupportBrowsers.includes(browserName);
-  const isLimitedSupport = limitedSupportBrowsers.includes(browserName);
+  const { isLimitedSupport, isFullSupport } = useBrowserSupport();
 
   const title = isLimitedSupport
     ? "Limited browser support"

--- a/packages/components/src/lib/test/Banner.test.tsx
+++ b/packages/components/src/lib/test/Banner.test.tsx
@@ -69,7 +69,8 @@ describe("<Banner />", () => {
     const banner = screen.getByTestId("banner");
     expect(banner).toHaveStyle({ position: "fixed" });
     expect(banner).toHaveStyle({ top: "0px" });
-    expect(banner).toHaveStyle({ zIndex: "1300" });
+    // * zIndex is theme.zIndex.snackbar - 1 (MUI default snackbar is 1400, so this is 1399)
+    expect(banner).toHaveStyle({ zIndex: "1399" });
   });
 
   it("does not apply fixed positioning when fixed is false", () => {
@@ -78,7 +79,7 @@ describe("<Banner />", () => {
     const banner = screen.getByTestId("banner");
     expect(banner).not.toHaveStyle({ position: "fixed" });
     expect(banner).not.toHaveStyle({ top: "0px" });
-    expect(banner).not.toHaveStyle({ zIndex: "1300" });
+    expect(banner).not.toHaveStyle({ zIndex: "1399" });
   });
 
   it("applies full width when fullWidth is true", () => {

--- a/packages/components/src/lib/test/Banner.test.tsx
+++ b/packages/components/src/lib/test/Banner.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import theme from "@newm-web/theme";
 import { renderWithContext } from "./utils/render";
 import Banner from "../Banner";
 
@@ -69,8 +70,9 @@ describe("<Banner />", () => {
     const banner = screen.getByTestId("banner");
     expect(banner).toHaveStyle({ position: "fixed" });
     expect(banner).toHaveStyle({ top: "0px" });
-    // * zIndex is theme.zIndex.snackbar - 1 (MUI default snackbar is 1400, so this is 1399)
-    expect(banner).toHaveStyle({ zIndex: "1399" });
+    // Derive expected zIndex from theme instead of hardcoding
+    const expectedZIndex = theme.zIndex.snackbar - 1;
+    expect(banner).toHaveStyle({ zIndex: String(expectedZIndex) });
   });
 
   it("does not apply fixed positioning when fixed is false", () => {
@@ -79,7 +81,8 @@ describe("<Banner />", () => {
     const banner = screen.getByTestId("banner");
     expect(banner).not.toHaveStyle({ position: "fixed" });
     expect(banner).not.toHaveStyle({ top: "0px" });
-    expect(banner).not.toHaveStyle({ zIndex: "1399" });
+    const expectedZIndex = theme.zIndex.snackbar - 1;
+    expect(banner).not.toHaveStyle({ zIndex: String(expectedZIndex) });
   });
 
   it("applies full width when fullWidth is true", () => {
@@ -100,15 +103,16 @@ describe("<Banner />", () => {
     renderWithContext(<Banner textAlign="left" title="Test" />);
 
     const banner = screen.getByTestId("banner");
-    expect(banner).toBeInTheDocument();
-    // MUI Box applies textAlign prop, verified by component rendering
+    // MUI Box applies textAlign as a style attribute
+    expect(banner).toHaveStyle({ textAlign: "left" });
   });
 
   it("defaults textAlign to center", () => {
     renderWithContext(<Banner title="Test" />);
 
     const banner = screen.getByTestId("banner");
-    expect(banner).toBeInTheDocument();
+    // Default textAlign is center
+    expect(banner).toHaveStyle({ textAlign: "center" });
   });
 
   it("applies sx prop to root Box", () => {
@@ -122,7 +126,8 @@ describe("<Banner />", () => {
     renderWithContext(<Banner title="Test" titleSx={ { fontWeight: 100 } } />);
 
     const title = screen.getByText("Test");
-    expect(title).toBeInTheDocument();
+    // Verify fontWeight is actually applied via computed styles
+    expect(title).toHaveStyle({ fontWeight: "100" });
   });
 
   it("applies default paddingX styles", () => {
@@ -160,7 +165,8 @@ describe("<Banner />", () => {
     renderWithContext(<Banner description="Description" title="Title" />);
 
     const description = screen.getByText("Description");
-    expect(description).toBeInTheDocument();
+    // Verify fontWeight 400 is actually applied
+    expect(description).toHaveStyle({ fontWeight: "400" });
   });
 
   it("merges sx prop with default styles", () => {

--- a/packages/components/src/lib/test/Banner.test.tsx
+++ b/packages/components/src/lib/test/Banner.test.tsx
@@ -1,0 +1,194 @@
+import { screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { renderWithContext } from "./utils/render";
+import Banner from "../Banner";
+
+describe("<Banner />", () => {
+  it("renders with title", () => {
+    renderWithContext(<Banner title="Test Banner" />);
+
+    expect(screen.getByText("Test Banner")).toBeInTheDocument();
+  });
+
+  it("renders title as ReactNode", () => {
+    renderWithContext(
+      <Banner title={ <span data-testid="custom-title">Custom Title</span> } />
+    );
+
+    expect(screen.getByTestId("custom-title")).toBeInTheDocument();
+    expect(screen.getByText("Custom Title")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    renderWithContext(
+      <Banner description="Test description" title="Test Banner" />
+    );
+
+    expect(screen.getByText("Test description")).toBeInTheDocument();
+  });
+
+  it("renders description as ReactNode", () => {
+    renderWithContext(
+      <Banner
+        description={ <span data-testid="custom-desc">Custom Description</span> }
+        title="Test Banner"
+      />
+    );
+
+    expect(screen.getByTestId("custom-desc")).toBeInTheDocument();
+    expect(screen.getByText("Custom Description")).toBeInTheDocument();
+  });
+
+  it("does not render description when not provided", () => {
+    renderWithContext(<Banner title="Test Banner" />);
+
+    expect(screen.queryByText("Test description")).not.toBeInTheDocument();
+  });
+
+  it("applies custom background", () => {
+    renderWithContext(
+      <Banner background="linear-gradient(90deg, #000, #fff)" title="Test" />
+    );
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toHaveStyle({
+      background: "linear-gradient(90deg, #000, #fff)",
+    });
+  });
+
+  it("applies custom text color", () => {
+    renderWithContext(<Banner textColor="#ff0000" title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toHaveStyle({ color: "rgb(255, 0, 0)" });
+  });
+
+  it("applies fixed positioning when fixed is true", () => {
+    renderWithContext(<Banner fixed={ true } title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toHaveStyle({ position: "fixed" });
+    expect(banner).toHaveStyle({ top: "0px" });
+    expect(banner).toHaveStyle({ zIndex: "1300" });
+  });
+
+  it("does not apply fixed positioning when fixed is false", () => {
+    renderWithContext(<Banner fixed={ false } title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).not.toHaveStyle({ position: "fixed" });
+    expect(banner).not.toHaveStyle({ top: "0px" });
+    expect(banner).not.toHaveStyle({ zIndex: "1300" });
+  });
+
+  it("applies full width when fullWidth is true", () => {
+    renderWithContext(<Banner fullWidth={ true } title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toHaveStyle({ width: "100%" });
+  });
+
+  it("does not apply full width when fullWidth is false", () => {
+    renderWithContext(<Banner fullWidth={ false } title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).not.toHaveStyle({ width: "100%" });
+  });
+
+  it("applies textAlign prop to Box", () => {
+    renderWithContext(<Banner textAlign="left" title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toBeInTheDocument();
+    // MUI Box applies textAlign prop, verified by component rendering
+  });
+
+  it("defaults textAlign to center", () => {
+    renderWithContext(<Banner title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toBeInTheDocument();
+  });
+
+  it("applies sx prop to root Box", () => {
+    renderWithContext(<Banner sx={ { marginTop: "20px" } } title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toHaveStyle({ marginTop: "20px" });
+  });
+
+  it("applies titleSx prop to title Typography", () => {
+    renderWithContext(<Banner title="Test" titleSx={ { fontWeight: 100 } } />);
+
+    const title = screen.getByText("Test");
+    expect(title).toBeInTheDocument();
+  });
+
+  it("applies default paddingX styles", () => {
+    renderWithContext(<Banner title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    // paddingX: 3 translates to 24px in MUI theme
+    expect(banner).toHaveStyle({ paddingLeft: "24px", paddingRight: "24px" });
+  });
+
+  it("renders Stack component", () => {
+    renderWithContext(<Banner title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    // Stack is rendered as a child of the banner
+    expect(banner).toBeInTheDocument();
+    expect(screen.getByText("Test")).toBeInTheDocument();
+  });
+
+  it("renders title with h4 variant", () => {
+    renderWithContext(<Banner title="Test" />);
+
+    const title = screen.getByText("Test");
+    expect(title.tagName).toBe("H4");
+  });
+
+  it("renders description with body1 variant", () => {
+    renderWithContext(<Banner description="Description" title="Title" />);
+
+    const description = screen.getByText("Description");
+    expect(description.tagName).toBe("P");
+  });
+
+  it("applies fontWeight 400 to description", () => {
+    renderWithContext(<Banner description="Description" title="Title" />);
+
+    const description = screen.getByText("Description");
+    expect(description).toBeInTheDocument();
+  });
+
+  it("merges sx prop with default styles", () => {
+    renderWithContext(
+      <Banner sx={ { marginTop: "20px", paddingLeft: "10px" } } title="Test" />
+    );
+
+    const banner = screen.getByTestId("banner");
+    expect(banner).toHaveStyle({ marginTop: "20px" });
+    // sx prop should override default paddingX
+    expect(banner).toHaveStyle({ paddingLeft: "10px" });
+  });
+
+  it("uses theme default background when background prop is not provided", () => {
+    renderWithContext(<Banner title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    // Component should render with default background from theme (theme.gradients.music)
+    expect(banner).toBeInTheDocument();
+    // Banner renders successfully with default background
+    expect(screen.getByText("Test")).toBeInTheDocument();
+  });
+
+  it("uses theme default text color when textColor prop is not provided", () => {
+    renderWithContext(<Banner title="Test" />);
+
+    const banner = screen.getByTestId("banner");
+    // Component should render with default color from theme (theme.colors.white = #FFFFFF)
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveStyle({ color: "rgb(255, 255, 255)" });
+  });
+});

--- a/packages/components/src/lib/test/Banner.test.tsx
+++ b/packages/components/src/lib/test/Banner.test.tsx
@@ -71,7 +71,7 @@ describe("<Banner />", () => {
     expect(banner).toHaveStyle({ position: "fixed" });
     expect(banner).toHaveStyle({ top: "0px" });
     // Derive expected zIndex from theme instead of hardcoding
-    const expectedZIndex = theme.zIndex.snackbar - 1;
+    const expectedZIndex = theme.zIndex.modal;
     expect(banner).toHaveStyle({ zIndex: String(expectedZIndex) });
   });
 
@@ -81,7 +81,7 @@ describe("<Banner />", () => {
     const banner = screen.getByTestId("banner");
     expect(banner).not.toHaveStyle({ position: "fixed" });
     expect(banner).not.toHaveStyle({ top: "0px" });
-    const expectedZIndex = theme.zIndex.snackbar - 1;
+    const expectedZIndex = theme.zIndex.modal;
     expect(banner).not.toHaveStyle({ zIndex: String(expectedZIndex) });
   });
 

--- a/packages/utils/src/lib/constants.ts
+++ b/packages/utils/src/lib/constants.ts
@@ -21,3 +21,9 @@ export const FIFTEEN_SECONDS_IN_MILLISECONDS = 15000;
  * 5 minutes in milliseconds
  */
 export const FIVE_MINUTES_IN_MILLISECONDS = 300000;
+
+/**
+ * Browser Support
+ */
+export const FULL_SUPPORT_BROWSERS = ["Chrome", "Brave", "Edge"] as const;
+export const LIMITED_SUPPORT_BROWSERS = ["Firefox"] as const;

--- a/packages/utils/src/lib/hooks.ts
+++ b/packages/utils/src/lib/hooks.ts
@@ -11,8 +11,11 @@ import {
 import { browserName } from "react-device-detect";
 
 import Hls from "hls.js";
+
 import { isProd } from "@newm-web/env";
 import { Song } from "@newm-web/types";
+
+import { FULL_SUPPORT_BROWSERS, LIMITED_SUPPORT_BROWSERS } from "./constants";
 import { UseHlsJsParams, UseHlsJsResult, WindowDimensions } from "./types";
 
 const hasWindow = typeof window !== "undefined";
@@ -345,11 +348,13 @@ export const useBetterMediaQuery = (mediaQueryString: string) => {
 };
 
 export const useBrowserSupport = () => {
-  const fullSupportBrowsers = ["Chrome", "Brave", "Edge"];
-  const limitedSupportBrowsers = ["Firefox"];
+  const isFullSupport = (FULL_SUPPORT_BROWSERS as readonly string[]).includes(
+    browserName
+  );
 
-  const isFullSupport = fullSupportBrowsers.includes(browserName);
-  const isLimitedSupport = limitedSupportBrowsers.includes(browserName);
+  const isLimitedSupport = (
+    LIMITED_SUPPORT_BROWSERS as readonly string[]
+  ).includes(browserName);
 
   return {
     isFullSupport,

--- a/packages/utils/src/lib/hooks.ts
+++ b/packages/utils/src/lib/hooks.ts
@@ -8,6 +8,8 @@ import {
   useRef,
   useState,
 } from "react";
+import { browserName } from "react-device-detect";
+
 import Hls from "hls.js";
 import { isProd } from "@newm-web/env";
 import { Song } from "@newm-web/types";
@@ -340,4 +342,17 @@ export const useBetterMediaQuery = (mediaQueryString: string) => {
   }, [mediaQueryString]);
 
   return matches;
+};
+
+export const useBrowserSupport = () => {
+  const fullSupportBrowsers = ["Chrome", "Brave", "Edge"];
+  const limitedSupportBrowsers = ["Firefox"];
+
+  const isFullSupport = fullSupportBrowsers.includes(browserName);
+  const isLimitedSupport = limitedSupportBrowsers.includes(browserName);
+
+  return {
+    isFullSupport,
+    isLimitedSupport,
+  };
 };


### PR DESCRIPTION
# Pull Request — Issue [STUD-575](https://projectnewm.atlassian.net/browse/STUD-575)

## Overview

> This PR implements a general service disruption banner across the NEWM Studio site to inform users about the discontinuation of NEWM Studio distribution and Stream Token sales. The banner is conditionally displayed based on a LaunchDarkly feature flag (`webStudioDisableDistributionAndSales`) and appears fixed at the top of the page on desktop viewports.  
> **Context**: This change was necessary to communicate important service updates to users in a prominent, non-intrusive manner. The banner provides a clear message with a link to the official statement, ensuring users are informed about changes affecting their releases.

---

## Files Summary

> **Total Changes:** 20 files  
> _(Counts of added, modified, and deleted files can be seen in the PR diff view.)_

<details>
<summary>Added (4)</summary>

- **`apps/studio/src/components/InfoBanner.tsx`**
  - — New component that renders a service disruption banner using the shared `Banner` component. Conditionally displays based on `webStudioDisableDistributionAndSales` LaunchDarkly flag. Uses `OfficialStatementCTA` component for the banner message. Fixed positioning on desktop viewports.
- **`apps/studio/src/components/OfficialStatementCTA.tsx`**
  - — Reusable component that renders the official statement CTA message with a link to the official statement page. Encapsulates the message text and link styling to avoid duplication across multiple locations (e.g. pages declared in tickets STUD-576, STUD-577 and STUD-578). Accepts configurable `href` and `linkText` props while maintaining consistent styling.
- **`packages/components/src/lib/test/Banner.test.tsx`**
  - — Comprehensive unit test suite for the `Banner` component with 22 test cases covering rendering, props, styling, and edge cases. Tests follow Testing Library best practices and avoid direct DOM node access.
- **`packages/components/src/lib/Banner.tsx`**
  - — Enhanced component API by replacing `titleFontWeight` prop with more flexible `titleSx` prop (SxProps<Theme>) and added `sx` prop for root Box styling. Added `data-testid="banner"` for testing purposes. This provides better flexibility and aligns with MUI patterns used throughout the codebase.

</details>

<details>
<summary>Modified (16)</summary>

- **`apps/studio/src/components/Background.tsx`**
  - — Added conditional top offset to the main content overlay when `webStudioDisableDistributionAndSales` is enabled: `top: theme.spacing(2)` for viewports between 960px and xl so content clears the fixed banner. Offset is applied via an `applyOffset` prop derived from the feature flag and browser support status (`isFullSupport` from `useBrowserSupport` hook). The offset is only applied for fully supported browsers (Chrome, Brave, Edge) to ensure the banner displays correctly for limited support (Firefox) and unsupported browsers. Includes a TODO to remove the breakpoint logic when the flag is retired.
- **`apps/studio/src/App.tsx`**
  - — Added `<InfoBanner />` component to the app root, positioned after `ScrollToTop` and before the main `Background` component to ensure it appears at the top of the viewport.
- **`apps/studio/src/components/index.ts`**
  - — Added export for `InfoBanner` component to make it available for import throughout the app.
- **`apps/studio/src/pages/home/Home.tsx`**
  - — Made button `top` positioning breakpoint-aware (only adjusts on mobile where banner is in flow, not on desktop where banner is fixed). Removed unused `useTheme` import. Added `useBreakpoint` hook for responsive logic.
- **`apps/studio/src/common/hooks.ts`**
  - — Added `useMemo` to `useBreakpoint` hook return value to ensure referential stability and prevent unnecessary re-renders if the returned object is used in dependency arrays. Modified to ensure `useBreakpoint` hook is available for responsive breakpoint utilities used by `InfoBanner` and page components for conditional styling based on viewport size.
- **`packages/components/src/index.ts`**
  - — Ensured `Banner` component is properly exported from the components package (may have been reordered or formatting updated).
- **`apps/studio/src/pages/home/SideBar.tsx`**
  - — Added conditional `marginTop` (5 theme units) when banner is displayed on desktop to prevent content overlap with the fixed banner. Removed unused `useTheme` hook import to fix variable shadowing issue.
- **`apps/studio/src/pages/login/Login.tsx`**
  - — Added conditional `marginTop` (5 theme units) when banner is displayed on desktop to ensure proper spacing below the fixed banner.
- **`apps/studio/src/pages/signUp/SignUp.tsx`**
  - — Added conditional `marginTop` (2 theme units) when banner is displayed on desktop to maintain proper layout spacing.
- **`apps/studio/src/pages/signUp/Welcome.tsx`**
  - — Added conditional `marginTop` (3 theme units) when banner is displayed on desktop to maintain proper layout spacing.
- **`apps/studio/src/pages/signUp/Verification.tsx`**
  - — Added conditional `marginTop` (4 theme units) when banner is displayed on desktop for consistent spacing.
- **`apps/studio/src/pages/forgotPassword/ForgotPassword.tsx`**
  - — Added conditional `marginTop` (5 theme units) when banner is displayed on desktop to maintain proper page layout.
- **`packages/utils/src/lib/constants.ts`**
  - — Added browser support constants `FULL_SUPPORT_BROWSERS` and `LIMITED_SUPPORT_BROWSERS` to centralize browser support configuration. These constants define which browsers have full support (Chrome, Brave, Edge) and limited support (Firefox), making it easier to maintain and update browser support lists in a single location. The constants use `as const` for type safety and are consumed by the `useBrowserSupport` hook.
- **`packages/utils/src/lib/hooks.ts`**
  - — Added new `useBrowserSupport` hook that detects browser support level and returns `isFullSupport` and `isLimitedSupport` flags. The hook uses the centralized browser support constants (`FULL_SUPPORT_BROWSERS` and `LIMITED_SUPPORT_BROWSERS`) from `constants.ts` and `react-device-detect` to identify browser types. This hook centralizes browser detection logic and is used by `Background.tsx` and `UnsupportedBrowserBanner.tsx` to conditionally apply layout offsets and display browser support warnings, ensuring consistent browser detection across the codebase.
- **`packages/components/src/lib/UnsupportedBrowserBanner.tsx`**
  - — Refactored to use the centralized `useBrowserSupport` hook from `@newm-web/utils` instead of inline browser detection logic. Removed duplicate browser support arrays and `browserName` import from `react-device-detect`, replacing them with the shared hook. This improves code maintainability and ensures consistent browser detection logic across components. The component now uses `isFullSupport` and `isLimitedSupport` from the hook to determine banner visibility and messaging.

</details>

---

## Impact

- **User Experience**: Users will now see a prominent banner at the top of the page (on desktop) informing them about service discontinuation when the feature flag is enabled. The banner is non-intrusive and provides a clear call-to-action link.
- **Layout Adjustments**: The `Background` component applies a conditional top offset to its overlay when the banner flag is on (960px–xl), providing a single point of layout control for content under the fixed banner. Page-level conditional `marginTop` on Login, SignUp, SideBar, etc. remains for per-page spacing where needed. Together, these ensure content is not obscured.
- **Component API Enhancement**: The `Banner` component now supports more flexible styling through `sx` and `titleSx` props, making it more reusable and consistent with MUI patterns.
- **Code Reusability**: Extracted `OfficialStatementCTA` component to avoid duplication of the official statement message across multiple locations, improving maintainability. Centralized browser detection logic into `useBrowserSupport` hook and browser support arrays into constants (`FULL_SUPPORT_BROWSERS`, `LIMITED_SUPPORT_BROWSERS`), eliminating duplicate browser support arrays and detection logic across components. This provides a single source of truth for browser support configuration.
- **Testing Coverage**: Added comprehensive unit tests for the `Banner` component, improving code quality and maintainability.
- **Performance**: Minimal impact - banner only renders when feature flag is enabled, and uses efficient conditional rendering.
- **Accessibility**: Banner uses semantic HTML and proper link attributes (`rel="noopener noreferrer"`, `target="_blank"`) for external links.

---

## Testing

- **Unit Tests**: Added 22 test cases for the `Banner` component covering:
  - Basic rendering with title and description (string and ReactNode)
  - All prop variations (background, textColor, fixed, fullWidth, textAlign, sx, titleSx)
  - Default values and theme fallbacks
  - Conditional rendering logic
  - Style application and prop merging

- **Manual Testing**:
  - Verified banner appears/disappears based on `webStudioDisableDistributionAndSales` flag
  - Confirmed fixed positioning works correctly on desktop viewports
  - Tested responsive behavior on mobile (banner not fixed)
  - Verified all page layouts maintain proper spacing when banner is displayed
  - Confirmed external link opens in new tab with proper security attributes
  - Tested banner visibility across all modified pages (Login, SignUp, Home, etc.)

- **Test Commands**:

```bash
# Run unit tests for the Banner component
npx nx test components --testPathPattern="Banner"

# Run all tests for the components package
npx nx test components
```

---

## Related Issues

- Closes [STUD-575](https://projectnewm.atlassian.net/browse/STUD-575)

---

## Dependencies

No new dependencies.

---

## Additional Notes

- All spacing adjustments use MUI theme units for consistency and responsive behavior.
- The banner is conditionally rendered based on both the feature flag and viewport size (fixed only on desktop).
- The implementation follows existing patterns in the codebase for feature flag usage and component composition.
- The `Banner` component now includes `data-testid="banner"` to support testing without direct DOM node access, following Testing Library best practices.
- Extracted `OfficialStatementCTA` component to centralize the official statement message and link, making it easier to update the message or link URL across all usages.
  - **🚨 The link uses `NEWM_IO_URL` pointing to `https://newm.io/`. Once Marketing finalizes with the "Official statement" webpage, we will need to append the webpage path.**

**Design Decision - Banner Height/Padding:**

- The banner padding was intentionally kept smaller than the Figma design specifications to minimize layout disruption across pages. Increasing the padding to match Figma exactly would require additional conditional `marginTop` adjustments on numerous page elements (titles, headers, etc.), creating more maintenance overhead and potential inconsistencies. The current implementation provides sufficient visual prominence while maintaining a cleaner, more maintainable codebase. The banner's current appearance is considered sufficient for its purpose of communicating the service disruption message. Nevertheless, I'm open to discussing adjustments if design alignment is prioritized or if feedback suggests the banner needs more visual weight. **Background overlay offset**: `Background.tsx` applies a responsive top offset (`theme.spacing(2)`) to the main content overlay when the banner is shown (flag on and browser is fully supported, viewport 960px–xl), so all routes inside `Background` are shifted down in one place. Per-page `marginTop` values are retained where specific screens need additional spacing below the banner.

**Code Quality Note - Theme Access Standardization:**

- During implementation, a theme variable shadowing issue was identified and fixed in `SideBar.tsx` (removed unused `useTheme()` hook call that was shadowing the imported `theme` object). This highlights an existing inconsistency across the codebase where some components use the imported theme object directly (`import theme from "@newm-web/theme"`), while others use the MUI theme hook (`const theme = useTheme()`). This inconsistency can lead to confusion and potential bugs. **Future work**: We should consider standardizing theme access patterns across the codebase to improve maintainability and reduce the risk of using the wrong theme object.

--END--


[STUD-575]: https://projectnewm.atlassian.net/browse/STUD-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-575]: https://projectnewm.atlassian.net/browse/STUD-575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ