### PR TITLE
[STUD-576][Enhancement]: Disable Create New Release button, implement tooltip and block routes

### DIFF
--- a/apps/studio/src/pages/createProfile/CreateProfile.tsx
+++ b/apps/studio/src/pages/createProfile/CreateProfile.tsx
@@ -1,9 +1,15 @@
 import { FunctionComponent, useMemo } from "react";
-import { Box, Container, useTheme } from "@mui/material";
-import { WizardForm } from "@newm-web/elements";
-import * as Yup from "yup";
-import { getUpdatedValues, removeTrailingSlash } from "@newm-web/utils";
 import { useLocation } from "react-router-dom";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
+import * as Yup from "yup";
+
+import { Box, Container, useTheme } from "@mui/material";
+
+import { WizardForm } from "@newm-web/elements";
+import { getUpdatedValues, removeTrailingSlash } from "@newm-web/utils";
+
 import Begin from "./Begin";
 import SelectNickname from "./SelectNickname";
 import SelectRole from "./SelectRole";
@@ -13,7 +19,7 @@ import AddLastName from "./AddLastName";
 import SelectLocation from "./SelectLocation";
 import NotFoundPage from "../NotFoundPage";
 import { useGetRolesQuery } from "../../modules/content";
-import { commonYupValidation } from "../../common";
+import { commonYupValidation, useBreakpoint } from "../../common";
 import {
   ProfileFormValues,
   emptyProfile,
@@ -24,7 +30,11 @@ import {
 const rootPath = "create-profile";
 
 const CreateProfile: FunctionComponent = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const theme = useTheme();
+  const { isDesktop } = useBreakpoint();
+
   const currentPathLocation = useLocation();
 
   const { data: roles = [] } = useGetRolesQuery();
@@ -127,6 +137,7 @@ const CreateProfile: FunctionComponent = () => {
         display: "flex",
         flex: 1,
         maxWidth: "100%",
+        mt: webStudioDisableDistributionAndSales && isDesktop ? 4 : 0,
         pt: 7.5,
         px: 2,
         textAlign: "center",

--- a/apps/studio/src/pages/home/Home.tsx
+++ b/apps/studio/src/pages/home/Home.tsx
@@ -143,7 +143,16 @@ const Home: FunctionComponent = () => {
               path=""
             />
 
-            <Route element={ <UploadSong /> } path="upload-song/*" />
+            <Route
+              element={
+                webStudioDisableDistributionAndSales ? (
+                  <Navigate to="/home/releases" replace />
+                ) : (
+                  <UploadSong />
+                )
+              }
+              path="upload-song/*"
+            />
 
             <Route
               element={

--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -43,8 +43,10 @@ const Discography: FunctionComponent = () => {
         { webStudioDisableDistributionAndSales ? (
           <Tooltip title={ <OfficialStatementCTA /> }>
             <Box
+              aria-disabled="true"
               aria-label="Create New Release"
               component="span"
+              role="button"
               sx={ {
                 cursor: "not-allowed",
                 textDecoration: "none",

--- a/apps/studio/src/pages/home/releases/Discography.tsx
+++ b/apps/studio/src/pages/home/releases/Discography.tsx
@@ -2,18 +2,25 @@ import { FunctionComponent, useState } from "react";
 
 import { Box, Typography } from "@mui/material";
 
-import { GradientDashedOutline, IconMessage, Link } from "@newm-web/elements";
-import { AddSong } from "@newm-web/assets";
-
 import { useFlags } from "launchdarkly-react-client-sdk";
 
+import {
+  GradientDashedOutline,
+  IconMessage,
+  Link,
+  Tooltip,
+} from "@newm-web/elements";
+import { AddSong } from "@newm-web/assets";
+
 import SongList from "./SongList";
+import OfficialStatementCTA from "../../../components/OfficialStatementCTA";
 import { SearchBox } from "../../../components";
 import { useGetSongCountQuery } from "../../../modules/song";
 
 const Discography: FunctionComponent = () => {
   // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
-  const { webStudioAlbumPhaseTwo } = useFlags();
+  const { webStudioAlbumPhaseTwo, webStudioDisableDistributionAndSales } =
+    useFlags();
 
   const [query, setQuery] = useState("");
 
@@ -33,23 +40,36 @@ const Discography: FunctionComponent = () => {
       </Typography>
 
       <Box sx={ { mb: 5.5 } }>
-        <Link
-          aria-label="Create New Release"
-          sx={ {
-            textDecoration: "none",
-          } }
-          to={
-            webStudioAlbumPhaseTwo ? "/home/releases/new" : "/home/upload-song"
-          }
-        >
-          <GradientDashedOutline
-            sx={ {
-              padding: 3,
-            } }
+        { webStudioDisableDistributionAndSales ? (
+          <Tooltip title={ <OfficialStatementCTA /> }>
+            <Box
+              aria-label="Create New Release"
+              component="span"
+              sx={ {
+                cursor: "not-allowed",
+                textDecoration: "none",
+              } }
+            >
+              <GradientDashedOutline sx={ { padding: 3 } }>
+                <IconMessage icon={ <AddSong /> } message="Create New Release" />
+              </GradientDashedOutline>
+            </Box>
+          </Tooltip>
+        ) : (
+          <Link
+            aria-label="Create New Release"
+            sx={ { textDecoration: "none" } }
+            to={
+              webStudioAlbumPhaseTwo
+                ? "/home/releases/new"
+                : "/home/upload-song"
+            }
           >
-            <IconMessage icon={ <AddSong /> } message="Create New Release" />
-          </GradientDashedOutline>
-        </Link>
+            <GradientDashedOutline sx={ { padding: 3 } }>
+              <IconMessage icon={ <AddSong /> } message="Create New Release" />
+            </GradientDashedOutline>
+          </Link>
+        ) }
       </Box>
 
       { totalCountOfSongs || query ? (

--- a/apps/studio/src/pages/home/releases/Releases.tsx
+++ b/apps/studio/src/pages/home/releases/Releases.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent } from "react";
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import { useFlags } from "launchdarkly-react-client-sdk";
 
@@ -16,7 +16,9 @@ import NotFoundPage from "../../NotFoundPage";
 
 const Releases: FunctionComponent = () => {
   // TODO(webStudioAlbumPhaseTwo): Remove flag once flag is retired.
-  const { webStudioAlbumPhaseTwo } = useFlags();
+  // TODO(webStudioDisableDistributionAndSales): Remove once flag is retired.
+  const { webStudioAlbumPhaseTwo, webStudioDisableDistributionAndSales } =
+    useFlags();
 
   return (
     <Container
@@ -40,11 +42,40 @@ const Releases: FunctionComponent = () => {
 
         { webStudioAlbumPhaseTwo && (
           <>
-            <Route element={ <ReleaseDetails /> } path="new/*" />
+            <Route
+              element={
+                webStudioDisableDistributionAndSales ? (
+                  <Navigate to="/home/releases" replace />
+                ) : (
+                  <ReleaseDetails />
+                )
+              }
+              path="new/*"
+            />
             <Route element={ <ReleaseDetails /> } path=":releaseId/*" />
 
-            <Route element={ <NewTrack /> } path="new/track/new" />
-            <Route element={ <NewTrack /> } path=":releaseId/track/new" />
+            <Route
+              element={
+                webStudioDisableDistributionAndSales ? (
+                  <Navigate to="/home/releases" replace />
+                ) : (
+                  <NewTrack />
+                )
+              }
+              path="new/track/new"
+            />
+
+            <Route
+              element={
+                webStudioDisableDistributionAndSales ? (
+                  <Navigate to="/home/releases" replace />
+                ) : (
+                  <NewTrack />
+                )
+              }
+              path=":releaseId/track/new"
+            />
+
             <Route
               element={ <TrackDetailsRouter /> }
               path=":releaseId/track/:trackId"


### PR DESCRIPTION
# Pull Request — Issue [STUD-576](https://projectnewm.atlassian.net/browse/STUD-576)

## Overview

> This PR disables the "Create New Release" action and all related "new" flows (new release, new track) when distribution and Stream Token sales are disabled, and shows an official statement CTA in a tooltip on the disabled button.  
> **Context:** When `webStudioDisableDistributionAndSales` is enabled, users must not start new releases or add new tracks. The button stays visible but is non-clickable, and a tooltip explains the change and links to the official statement. Direct navigation to `/home/upload-song`, `/home/releases/new`, and new-track routes is redirected to `/home/releases`. Create Profile gets conditional margin-top on desktop so content clears the fixed banner when the flag is on.

---

## Files Summary

> **Total Changes:** 4 files  
> _(Counts of added, modified, and deleted files can be seen in the PR diff view.)_

<details>
<summary>Modified (4)</summary>

- **`apps/studio/src/pages/createProfile/CreateProfile.tsx`**
  - — Conditional margin-top when the service disruption banner is shown on desktop: `mt: webStudioDisableDistributionAndSales && isDesktop ? 4 : 0` on the root `Box` so the create-profile wizard content clears the fixed banner. Uses `useFlags()` for `webStudioDisableDistributionAndSales` and `useBreakpoint()` for `isDesktop`.

- **`apps/studio/src/pages/home/releases/Discography.tsx`**
  - — When `webStudioDisableDistributionAndSales` is on, the "Create New Release" control is no longer a link: it is rendered as a non-clickable `Box` (span) with `cursor: not-allowed`, wrapped in a MUI `Tooltip` whose title is the existing `OfficialStatementCTA` component (message + link to official statement). When the flag is off, behavior is unchanged (link to `/home/releases/new` or `/home/upload-song` depending on `webStudioAlbumPhaseTwo`). Added `webStudioDisableDistributionAndSales` from `useFlags()` and `OfficialStatementCTA` import.

- **`apps/studio/src/pages/home/releases/Releases.tsx`**
  - — Route guards for distribution-related flows: when `webStudioDisableDistributionAndSales` is on, `new/*`, `new/track/new`, and `:releaseId/track/new` render `<Navigate to="/home/releases" replace />` instead of `ReleaseDetails` or `NewTrack`. This blocks creating new releases and adding new tracks via URL. Added `Navigate` import and `webStudioDisableDistributionAndSales` from `useFlags()`. TODO comment added for flag retirement.

- **`apps/studio/src/pages/home/Home.tsx`**
  - — The `upload-song/*` route is gated: when `webStudioDisableDistributionAndSales` is on, users are redirected to `/home/releases` instead of the `UploadSong` page. When the flag is off, the route behaves as before.

</details>

---

## Impact

- **Releases / Discography:** When distribution is disabled, "Create New Release" is visible but disabled and shows the official statement CTA in a tooltip, so users understand why and where to read more.
- **Routing:** Direct access to upload-song, new release, and new track routes is blocked when the flag is on; users are sent to `/home/releases` so they cannot start new distribution flows.
- **Layout:** Create Profile page uses conditional `marginTop` (4 theme units) on desktop when the banner is shown so the wizard is not hidden under the fixed banner.
- **Feature flag:** All behavior is behind `webStudioDisableDistributionAndSales`. No change when the flag is off.
- **Dependencies:** Uses existing `OfficialStatementCTA` component and LaunchDarkly flags; no new dependencies.

---

## Testing

- With `webStudioDisableDistributionAndSales` **on**: "Create New Release" is disabled and shows tooltip with official statement CTA; visiting `/home/upload-song`, `/home/releases/new`, `/home/releases/new/track/new`, or `/:releaseId/track/new` redirects to `/home/releases`; Create Profile page has extra top margin on desktop so content clears the banner.
- With the flag **off**: "Create New Release" works as before; all above routes render their normal content; Create Profile has no extra margin.
- Manual check: tooltip opens on hover; link in tooltip opens in new tab; redirects use `replace` so back button is not stuck in a loop; Create Profile layout on desktop with banner on looks correct.

---

## Demo

<img width="1357" height="673" alt="STUD-576-demo" src="https://github.com/user-attachments/assets/2381ea55-939c-4b67-944d-36d71b05d426" />

<img width="1364" height="683" alt="STUD-576-demo-2" src="https://github.com/user-attachments/assets/3c20226a-aea9-485b-8ec9-9657a05f16f9" />

---

## Related Issues

- Closes [STUD-576](https://projectnewm.atlassian.net/browse/STUD-576)

---

## Dependencies

No new dependencies.

---

## Additional Notes

- TODOs in code reference retiring `webStudioDisableDistributionAndSales` and `webStudioAlbumPhaseTwo` once flags are removed.
- `OfficialStatementCTA` is reused from the studio app (e.g. STUD-575); no new CTA component in this PR.

--END--


[STUD-576]: https://projectnewm.atlassian.net/browse/STUD-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-576]: https://projectnewm.atlassian.net/browse/STUD-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ