### PR TITLE
[STUD-577][Enhancement]: Disable "Distribute & Mint Song" toggle option and "Upload" button and render updated tooltip

### DIFF
--- a/apps/studio/src/components/index.ts
+++ b/apps/studio/src/components/index.ts
@@ -1,7 +1,6 @@
 // ! List exports in alphabetical order by component name.
 
 export { default as AddProfileInformation } from "./createProfile/AddProfileInformation";
-export { default as AppleLogin } from "./AppleLogin";
 export { default as Background } from "./Background";
 export { default as ConfirmContract } from "./minting/ConfirmContract";
 export { default as ConnectWalletModal } from "./ConnectWalletModal";
@@ -9,11 +8,11 @@ export { CoverRemixSample } from "./minting/CoverRemixSample";
 export { default as Creditors } from "./minting/Creditors";
 export { default as DisconnectWalletButton } from "./DisconnectWalletButton";
 export { default as DistributionPricingDialog } from "./dspPricing/DistributionPricingDialog";
+export { default as AppleLogin } from "./AppleLogin";
 export { default as GoogleLogin } from "./GoogleLogin";
 export * from "./releases/IconStatus";
 export { default as IconStatus } from "./releases/IconStatus";
 export * from "./idenfy";
-export { default as InfoBanner } from "./InfoBanner";
 export { default as InvitesModal } from "./invites/InvitesModal";
 export { default as LogoutButton } from "./home/LogoutButton";
 export { default as MarketplaceTabSkeleton } from "./skeletons/MarketplaceTabSkeleton";
@@ -44,3 +43,4 @@ export { default as Toast } from "./Toast";
 export { default as UpdateWalletAddressModal } from "./UpdateWalletAddressModal";
 export { default as ViewPDF } from "./ViewPDF";
 export { default as WalletEnvMismatchModal } from "./WalletEnvMismatchModal";
+export { default as InfoBanner } from "./InfoBanner";

--- a/apps/studio/src/components/index.ts
+++ b/apps/studio/src/components/index.ts
@@ -43,3 +43,4 @@ export { default as UpdateWalletAddressModal } from "./UpdateWalletAddressModal"
 export { default as ViewPDF } from "./ViewPDF";
 export { default as WalletEnvMismatchModal } from "./WalletEnvMismatchModal";
 export { default as InfoBanner } from "./InfoBanner";
+export { default as OfficialStatementCTA } from "./OfficialStatementCTA";

--- a/apps/studio/src/components/index.ts
+++ b/apps/studio/src/components/index.ts
@@ -1,6 +1,7 @@
-// List exports in alphabetical order by component name
+// ! List exports in alphabetical order by component name.
 
 export { default as AddProfileInformation } from "./createProfile/AddProfileInformation";
+export { default as AppleLogin } from "./AppleLogin";
 export { default as Background } from "./Background";
 export { default as ConfirmContract } from "./minting/ConfirmContract";
 export { default as ConnectWalletModal } from "./ConnectWalletModal";
@@ -8,15 +9,16 @@ export { CoverRemixSample } from "./minting/CoverRemixSample";
 export { default as Creditors } from "./minting/Creditors";
 export { default as DisconnectWalletButton } from "./DisconnectWalletButton";
 export { default as DistributionPricingDialog } from "./dspPricing/DistributionPricingDialog";
-export { default as AppleLogin } from "./AppleLogin";
 export { default as GoogleLogin } from "./GoogleLogin";
 export * from "./releases/IconStatus";
 export { default as IconStatus } from "./releases/IconStatus";
 export * from "./idenfy";
+export { default as InfoBanner } from "./InfoBanner";
 export { default as InvitesModal } from "./invites/InvitesModal";
 export { default as LogoutButton } from "./home/LogoutButton";
 export { default as MarketplaceTabSkeleton } from "./skeletons/MarketplaceTabSkeleton";
 export { default as NEWMLogo } from "./NEWMLogo";
+export { default as OfficialStatementCTA } from "./OfficialStatementCTA";
 export { default as Owners } from "./minting/Owners";
 export { default as PingEarningsInProgressWrapper } from "./PingEarningsInProgressWrapper";
 export { default as PingSaleEnd } from "./sales/PingSaleEnd";
@@ -42,5 +44,3 @@ export { default as Toast } from "./Toast";
 export { default as UpdateWalletAddressModal } from "./UpdateWalletAddressModal";
 export { default as ViewPDF } from "./ViewPDF";
 export { default as WalletEnvMismatchModal } from "./WalletEnvMismatchModal";
-export { default as InfoBanner } from "./InfoBanner";
-export { default as OfficialStatementCTA } from "./OfficialStatementCTA";

--- a/apps/studio/src/pages/home/releases/EditSong.tsx
+++ b/apps/studio/src/pages/home/releases/EditSong.tsx
@@ -42,7 +42,10 @@ interface EditSongFormValues extends PatchSongThunkRequest {
 }
 
 const EditSong: FunctionComponent = () => {
-  const { webStudioDisableTrackDistributionAndMinting } = useFlags();
+  const {
+    webStudioDisableTrackDistributionAndMinting,
+    webStudioDisableDistributionAndSales,
+  } = useFlags();
 
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -177,7 +180,8 @@ const EditSong: FunctionComponent = () => {
     isMinting:
       isArtistPricePlanSelected &&
       isSongEditable(mintingStatus) &&
-      !webStudioDisableTrackDistributionAndMinting,
+      !webStudioDisableTrackDistributionAndMinting &&
+      !webStudioDisableDistributionAndSales,
     isrc,
     iswc,
     language,

--- a/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -162,7 +162,8 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
   const isSubmitDisabled =
     !values.agreesToCoverArtGuidelines ||
     (isMintingVisible && (!wallet || !isVerified)) ||
-    (values.isMinting && isDistributionDisabled);
+    (values.isMinting && isDistributionDisabled) ||
+    isDistributionDisabled;
 
   const handleChangeOwners = (owners: ReadonlyArray<Owner>) => {
     setFieldValue("owners", owners);
@@ -536,7 +537,13 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
           <Box>
             <HorizontalLine mb={ 5 } />
 
-            <Tooltip title={ tooltipContent }>
+            <Tooltip
+              title={
+                isSubmitDisabled && isDistributionDisabled
+                  ? tooltipContent
+                  : undefined
+              }
+            >
               <span>
                 <Button
                   disabled={ isSubmitDisabled }

--- a/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
+++ b/apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx
@@ -1,4 +1,12 @@
+import { FunctionComponent, useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { useFlags } from "launchdarkly-react-client-sdk";
+
+import { useFormikContext } from "formik";
+
 import { Box, Link, Stack, Typography, useTheme } from "@mui/material";
+
 import {
   Alert,
   Button,
@@ -11,6 +19,7 @@ import {
   SwitchInputField,
   TextAreaField,
   TextInputField,
+  Tooltip,
   UploadImageField,
   UploadSongField,
 } from "@newm-web/elements";
@@ -19,19 +28,20 @@ import {
   useExtractProperty,
   useWindowDimensions,
 } from "@newm-web/utils";
-import { useConnectWallet } from "@newm.io/cardano-dapp-wallet-connector";
-import { useFormikContext } from "formik";
-import { FunctionComponent, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
 import { MintingStatus } from "@newm-web/types";
-import { useFlags } from "launchdarkly-react-client-sdk";
+import { useConnectWallet } from "@newm.io/cardano-dapp-wallet-connector";
+
 import { UploadSongFormValues } from "./UploadSong";
 import {
   NEWM_STUDIO_FAQ_URL,
   SONG_DESCRIPTION_MAX_CHARACTER_COUNT,
   useAppDispatch,
 } from "../../../common";
-import { DistributionPricingDialog, PlaySong } from "../../../components";
+import {
+  DistributionPricingDialog,
+  OfficialStatementCTA,
+  PlaySong,
+} from "../../../components";
 import SelectCoCreators from "../../../components/minting/SelectCoCreators";
 import {
   useGetGenresQuery,
@@ -76,6 +86,25 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
   const songDetailsRef = useRef<HTMLDivElement>(null);
 
   const {
+    webStudioDisableTrackDistributionAndMinting,
+    webStudioDisableDistributionAndSales,
+  } = useFlags();
+
+  const isDistributionDisabled =
+    webStudioDisableDistributionAndSales ||
+    webStudioDisableTrackDistributionAndMinting;
+  const shouldUseNewTooltip = webStudioDisableDistributionAndSales; // * New flag takes precedence.
+  const tooltipContent = shouldUseNewTooltip ? (
+    <OfficialStatementCTA />
+  ) : webStudioDisableTrackDistributionAndMinting ? (
+    <>
+      Track distribution and minting are temporarily disabled, but we&apos;re
+      working on it! You can still upload your tracks and song details to save
+      for later. Check back in a bit for updates.
+    </>
+  ) : undefined;
+
+  const {
     data: {
       verificationStatus,
       dspPlanSubscribed: isArtistPricePlanSelected,
@@ -83,7 +112,6 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
       appleMusicProfile,
     } = emptyProfile,
   } = useGetProfileQuery();
-  const { webStudioDisableTrackDistributionAndMinting } = useFlags();
   const { data: genres = [] } = useGetGenresQuery();
   const { data: moodOptions = [] } = useGetMoodsQuery();
   const { data: languages = [] } = useGetLanguagesQuery();
@@ -134,7 +162,7 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
   const isSubmitDisabled =
     !values.agreesToCoverArtGuidelines ||
     (isMintingVisible && (!wallet || !isVerified)) ||
-    (values.isMinting && webStudioDisableTrackDistributionAndMinting);
+    (values.isMinting && isDistributionDisabled);
 
   const handleChangeOwners = (owners: ReadonlyArray<Owner>) => {
     setFieldValue("owners", owners);
@@ -408,19 +436,11 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
                     "Distribute your track to all major streaming platforms " +
                     "and generate stream tokens for royalty claiming."
                   }
-                  disabled={
-                    isDeclined || webStudioDisableTrackDistributionAndMinting
-                  }
+                  disabled={ isDeclined || isDistributionDisabled }
                   includeBorder={ false }
                   name="isMinting"
                   title="DISTRIBUTE & MINT SONG"
-                  toggleTooltipText={
-                    webStudioDisableTrackDistributionAndMinting
-                      ? "Track distribution and minting are temporarily disabled, " +
-                        "but we're working on it! You can still upload your tracks and " +
-                        "song details to save for later. Check back in a bit for updates."
-                      : undefined
-                  }
+                  toggleTooltipText={ tooltipContent }
                   onClick={ () => {
                     if (!isArtistPricePlanSelected) handlePricingPlanOpen();
                   } }
@@ -516,18 +536,22 @@ const BasicSongDetails: FunctionComponent<BasicSongDetailsProps> = ({
           <Box>
             <HorizontalLine mb={ 5 } />
 
-            <Button
-              disabled={ isSubmitDisabled }
-              isLoading={ isSubmitting }
-              type="submit"
-              width={
-                windowWidth && windowWidth > theme.breakpoints.values.md
-                  ? "compact"
-                  : "default"
-              }
-            >
-              { isMintingVisible ? "Next" : isInEditMode ? "Save" : "Upload" }
-            </Button>
+            <Tooltip title={ tooltipContent }>
+              <span>
+                <Button
+                  disabled={ isSubmitDisabled }
+                  isLoading={ isSubmitting }
+                  type="submit"
+                  width={
+                    windowWidth && windowWidth > theme.breakpoints.values.md
+                      ? "compact"
+                      : "default"
+                  }
+                >
+                  { isMintingVisible ? "Next" : isInEditMode ? "Save" : "Upload" }
+                </Button>
+              </span>
+            </Tooltip>
           </Box>
         </Stack>
       </Stack>

--- a/packages/elements/src/lib/SwitchInput.tsx
+++ b/packages/elements/src/lib/SwitchInput.tsx
@@ -1,3 +1,5 @@
+import { FunctionComponent, ReactNode } from "react";
+
 import {
   IconButton,
   Stack,
@@ -6,8 +8,8 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import { FunctionComponent, ReactNode } from "react";
 import HelpIcon from "@mui/icons-material/Help";
+
 import Switch from "./Switch";
 import Tooltip from "./styled/Tooltip";
 
@@ -16,7 +18,7 @@ export interface SwitchInputProps extends SwitchProps {
   readonly description?: string;
   readonly includeBorder?: boolean;
   readonly title: string;
-  readonly toggleTooltipText?: string;
+  readonly toggleTooltipText?: ReactNode;
   readonly tooltipText?: string;
 }
 

--- a/packages/elements/src/lib/form/SwitchInputField.tsx
+++ b/packages/elements/src/lib/form/SwitchInputField.tsx
@@ -1,6 +1,9 @@
-import { SwitchProps } from "@mui/material";
-import { Field, FieldProps } from "formik";
 import { FunctionComponent, ReactNode } from "react";
+
+import { SwitchProps } from "@mui/material";
+
+import { Field, FieldProps } from "formik";
+
 import SwitchInput from "../SwitchInput";
 
 interface SwitchInputFieldProps extends SwitchProps {
@@ -9,7 +12,7 @@ interface SwitchInputFieldProps extends SwitchProps {
   readonly includeBorder?: boolean;
   readonly name: string;
   readonly title: string;
-  readonly toggleTooltipText?: string;
+  readonly toggleTooltipText?: ReactNode;
   readonly tooltipText?: string;
 }
 


### PR DESCRIPTION
# Pull Request — Issue [STUD-577](https://projectnewm.atlassian.net/browse/STUD-577)

## Overview

> This PR disables the "Distribute & Mint Song" toggle option and "Upload" button on the Upload a Song page when the `webStudioDisableDistributionAndSales` feature flag is enabled, and displays an updated tooltip with the official statement CTA.  
> Context: As part of NEWM Studio's service sunset, we need to prevent users from creating new releases and uploading songs. This PR implements the UI-level blocking for the upload flow, complementing the route-level blocking implemented in previous PRs. The new flag takes precedence over the existing `webStudioDisableTrackDistributionAndMinting` flag for tooltip content while maintaining backward compatibility.

---

## Files Summary

> **Total Changes:** 5 files modified  
> _(Counts of added, modified, and deleted files can be seen in the PR diff view.)_

<details>
<summary>Modified (5)</summary>

- **`apps/studio/src/pages/home/uploadSong/BasicSongDetails.tsx`**
  - — Added support for `webStudioDisableDistributionAndSales` feature flag
  - — Disabled "Distribute & Mint Song" toggle when either flag is enabled (`isDistributionDisabled`)
  - — Disabled "Upload"/"Next"/"Save" button when distribution is disabled (via `isSubmitDisabled` logic)
  - — Implemented tooltip logic that prioritizes new flag's `OfficialStatementCTA` component over old flag's string tooltip
  - — Wrapped Upload button in Tooltip component to show tooltip on hover
  - — Refactored tooltip content to be reusable for both toggle and button

- **`apps/studio/src/pages/home/releases/EditSong.tsx`**
  - — Added support for `webStudioDisableDistributionAndSales` feature flag for new condition for `isMinting` initial value.

- **`packages/elements/src/lib/SwitchInput.tsx`**
  - — Updated `toggleTooltipText` prop type from `string` to `ReactNode` to support JSX tooltip content
  - — Reorganized imports for better consistency

- **`packages/elements/src/lib/form/SwitchInputField.tsx`**
  - — Updated `toggleTooltipText` prop type from `string` to `ReactNode` to match `SwitchInput` interfaceF
  - — Reorganized imports for better consistency

- **`apps/studio/src/components/index.ts`**
  - — Added `OfficialStatementCTA` component to barrel exports

</details>

---

## Impact

- **User Experience**: When `webStudioDisableDistributionAndSales` is enabled, users cannot toggle on distribution/minting or submit the upload form. Tooltips provide clear messaging about the service discontinuation with a link to the official statement.
- **Backward Compatibility**: The existing `webStudioDisableTrackDistributionAndMinting` flag continues to work as before. When both flags are enabled, the new flag's tooltip takes precedence.
- **Component API**: The `toggleTooltipText` prop in `SwitchInput` and `SwitchInputField` now accepts `ReactNode` instead of just `string`, enabling richer tooltip content (backward compatible since `ReactNode` includes `string`).
- **Route-Level Protection**: The Upload a Song path (`/home/upload-song`) is blocked as part of [STUD-576](https://projectnewm.atlassian.net/browse/STUD-576) changes, so users won't be able to reach this page. However, since `UploadSong` component uses `BasicSongDetails`, the switch/toggle and buttons will still be disabled and show tooltips as a defense-in-depth measure.

---

## Testing

- **Manual Testing**:
  - ✅ Verified "Distribute & Mint Song" toggle is disabled when `webStudioDisableDistributionAndSales` is enabled
  - ✅ Verified toggle shows `OfficialStatementCTA` tooltip on hover when new flag is enabled
  - ✅ Verified toggle shows old tooltip text when only `webStudioDisableTrackDistributionAndMinting` is enabled
  - ✅ Verified "Upload"/"Next"/"Save" button is disabled when distribution is disabled
  - ✅ Verified Upload button shows tooltip on hover when flag is enabled
  - ✅ Verified backward compatibility with existing `webStudioDisableTrackDistributionAndMinting` flag
  - ✅ Verified tooltip content renders correctly with link to official statement

- **Component Testing**:
  - ✅ Verified `SwitchInput` and `SwitchInputField` accept both string and ReactNode for `toggleTooltipText` prop

---

## Related Issues

- Closes [STUD-577](https://projectnewm.atlassian.net/browse/STUD-577)
- Related to [STUD-576](https://projectnewm.atlassian.net/browse/STUD-576) (Route-level blocking for upload/release creation paths)
- Related to [STUD-574](https://projectnewm.atlassian.net/browse/STUD-574) (Create LaunchDarkly flag for halted distribution and stream token creation functionality)

---

## Dependencies

- No new dependencies.
- Uses existing `OfficialStatementCTA` component (already implemented in previous PRs)
- Uses existing `NEWM_STUDIO_OFFICIAL_STATEMENT_URL` constant from `common/constants.ts`

---

## Demo

- When `webStudioDisableDistributionAndSales` is enabled:
  - "Distribute & Mint Song" toggle appears disabled and shows tooltip with official statement CTA on hover
  - "Upload" button appears disabled and shows same tooltip on hover
  - Tooltip includes link to `https://newm.io/sunset/` for official statement

https://github.com/user-attachments/assets/b4869eea-add9-4428-ac77-1bf3157b5975

---

## Additional Notes

- **Flag Precedence**: The new `webStudioDisableDistributionAndSales` flag takes precedence over `webStudioDisableTrackDistributionAndMinting` for tooltip content, but both flags contribute to disabling the controls (OR logic).
- **Route Blocking**: The Upload a Song path (`/home/upload-song`) is blocked as part of [STUD-576](https://projectnewm.atlassian.net/browse/STUD-576) changes, preventing users from accessing the page. This PR implements UI-level disabling as defense in depth—since `UploadSong` component uses `BasicSongDetails`, the switch/toggle and buttons will be disabled and show tooltips even if users somehow access the page (e.g., cached page, or edge cases).
- **Component Type Update**: The change from `string` to `ReactNode` for `toggleTooltipText` is backward compatible since `ReactNode` includes `string` in its type definition.
- **Future Cleanup**: Once the new flag is deployed to Production and the old `webStudioDisableTrackDistributionAndMinting` flag is disabled, only the new flag will be active for this functionality.

## Other Issues

**Circular Dependency Issue Discovered**: During development, reordering exports in `apps/studio/src/components/index.ts` (alphabetically) exposed a pre-existing circular dependency: `store.ts` → `modules/session` → `slice.ts` → `api/actions.ts` → `modules/session` (barrel), causing **"Cannot access 'sessionReducer' before initialization"** errors. The reorder was rolled back to keep this PR scoped.
  - **Possible Fix**:
    - Update `api/actions.ts` and `api/utils.ts` to import `NewmAuthResponse` from `../modules/session/types` instead of `../modules/session` (barrel) to break the cycle. **Action Item**: Open a new ticket to fix this circular dependency properly so barrel exports can be safely reordered in the future. --> Stop the dev server -> Delete .nx cache folder (or run nx reset) -> Restart the dev server

--END--


[STUD-577]: https://projectnewm.atlassian.net/browse/STUD-577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-576]: https://projectnewm.atlassian.net/browse/STUD-576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ