### PR TITLE
[STUD-578][Enhancement]: Update Marketplace Tab with refined alert copy, page content, and limited functionality

### DIFF
--- a/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx
@@ -1,10 +1,16 @@
 import { FunctionComponent, useState } from "react";
 import { useParams } from "react-router-dom";
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import currency from "currency.js";
+
 import { AlertTitle, Stack, Typography } from "@mui/material";
+import { Close } from "@mui/icons-material";
+
 import { Alert, Button, HorizontalLine } from "@newm-web/elements";
 import theme from "@newm-web/theme";
 import { Sale } from "@newm-web/types";
+
 import { EndSaleModal } from "./EndSaleModal";
 import { SongRouteParams } from "../../../../common/types";
 import { useEndSaleThunk } from "../../../../modules/sale";
@@ -14,7 +20,43 @@ interface ActiveSaleProps {
   readonly sale?: Sale;
 }
 
+const SundownButtons = ({
+  saleId,
+  isEndSaleLoading,
+  setIsEndSaleModalOpen,
+}: {
+  isEndSaleLoading: boolean;
+  saleId: string;
+  setIsEndSaleModalOpen: (isOpen: boolean) => void;
+}) => {
+  return (
+    <>
+      <Button
+        color="music"
+        component="a"
+        href={ `${NEWM_MARKETPLACE_URL}/sale/${saleId}/` }
+        target="_blank"
+        variant="secondary"
+        width="compact"
+      >
+        View on Marketplace
+      </Button>
+      <Button
+        disabled={ isEndSaleLoading }
+        startIcon={ <Close /> }
+        variant="primary"
+        width="compact"
+        onClick={ () => setIsEndSaleModalOpen(true) }
+      >
+        End stream token sale
+      </Button>
+    </>
+  );
+};
+
 export const ActiveSale: FunctionComponent<ActiveSaleProps> = ({ sale }) => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const [isEndSaleModalOpen, setIsEndSaleModalOpen] = useState(false);
   const { songId } = useParams<"songId">() as SongRouteParams;
   const [endSale, { isLoading: isEndSaleLoading }] = useEndSaleThunk();
@@ -38,43 +80,69 @@ export const ActiveSale: FunctionComponent<ActiveSaleProps> = ({ sale }) => {
     <Stack sx={ { gap: 2.5, mt: 1 } }>
       <Alert>
         <AlertTitle color={ theme.colors.blue } sx={ { fontWeight: 600 } }>
-          You already have an active stream token sale for this track on the
-          Marketplace!
+          { webStudioDisableDistributionAndSales
+            ? "You have an active Stream Token sale for this track on the Marketplace!"
+            : "You already have an active stream token sale for this track on the Marketplace!" }
         </AlertTitle>
-        <Typography
-          color={ theme.colors.blue }
-          fontWeight={ 500 }
-          variant="subtitle1"
-        >
-          { `There are ${currency(sale.availableBundleQuantity, {
-            precision: 0,
-            symbol: "",
-          }).format()} remaining stream tokens available for sale.` }
-        </Typography>
+
+        { webStudioDisableDistributionAndSales && (
+          <Typography fontWeight={ 500 } variant="subtitle1">
+            Please end the sale and we&apos;ll return the unsold Stream Tokens
+            to your wallet.
+          </Typography>
+        ) }
+
+        { !webStudioDisableDistributionAndSales && (
+          <Typography
+            color={ theme.colors.blue }
+            fontWeight={ 500 }
+            variant="subtitle1"
+          >
+            { `There are ${currency(sale.availableBundleQuantity, {
+              precision: 0,
+              symbol: "",
+            }).format()} remaining stream tokens available for sale.` }
+          </Typography>
+        ) }
       </Alert>
-      <Typography mt={ 2.5 } variant="subtitle2">
-        You can choose to end this sale, and we&apos;ll return the unsold stream
-        tokens to your wallet.
-      </Typography>
-      <HorizontalLine />
-      <Stack flexDirection="row" gap={ 2.5 }>
-        <Button
-          component="a"
-          href={ `${NEWM_MARKETPLACE_URL}/sale/${saleId}/` }
-          target="_blank"
-          width="compact"
-        >
-          View on Marketplace
-        </Button>
-        <Button
-          color="music"
-          disabled={ isEndSaleLoading }
-          variant="secondary"
-          width="compact"
-          onClick={ () => setIsEndSaleModalOpen(true) }
-        >
-          End stream token sale
-        </Button>
+
+      { !webStudioDisableDistributionAndSales && (
+        <Typography mt={ 2.5 } variant="subtitle2">
+          You can choose to end this sale, and we&apos;ll return the unsold
+          stream tokens to your wallet.
+        </Typography>
+      ) }
+
+      { !webStudioDisableDistributionAndSales && <HorizontalLine /> }
+
+      <Stack flexDirection="row" gap={ 2.5 } mt={ 1.5 }>
+        { webStudioDisableDistributionAndSales ? (
+          <SundownButtons
+            isEndSaleLoading={ isEndSaleLoading }
+            saleId={ saleId ?? "" }
+            setIsEndSaleModalOpen={ setIsEndSaleModalOpen }
+          />
+        ) : (
+          <>
+            <Button
+              component="a"
+              href={ `${NEWM_MARKETPLACE_URL}/sale/${saleId}/` }
+              target="_blank"
+              width="compact"
+            >
+              View on Marketplace
+            </Button>
+            <Button
+              color="music"
+              disabled={ isEndSaleLoading }
+              variant="secondary"
+              width="compact"
+              onClick={ () => setIsEndSaleModalOpen(true) }
+            >
+              End stream token sale
+            </Button>
+          </>
+        ) }
       </Stack>
       <EndSaleModal
         handleClose={ () => setIsEndSaleModalOpen(false) }

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx
@@ -20,6 +20,7 @@ interface ActiveSaleProps {
   readonly sale?: Sale;
 }
 
+// TODO: Remove once 'webStudioDisableDistributionAndSales' retires.
 const SundownButtons = ({
   saleId,
   isEndSaleLoading,

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/ConnectWallet.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/ConnectWallet.tsx
@@ -11,6 +11,7 @@ import { Alert, Button } from "@newm-web/elements";
 import { useAppDispatch } from "../../../../common";
 import { setIsConnectWalletModalOpen } from "../../../../modules/ui";
 
+// TODO: Remove once 'webStudioDisableDistributionAndSales' retires.
 const SundownAlertCopy = ({
   wallet,
 }: {

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/ConnectWallet.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/ConnectWallet.tsx
@@ -1,11 +1,34 @@
+import { useFlags } from "launchdarkly-react-client-sdk";
+
 import { Stack, Typography } from "@mui/material";
-import { useConnectWallet } from "@newm.io/cardano-dapp-wallet-connector";
+
+import {
+  EnabledWallet,
+  useConnectWallet,
+} from "@newm.io/cardano-dapp-wallet-connector";
 import { Alert, Button } from "@newm-web/elements";
-import theme from "@newm-web/theme";
+
 import { useAppDispatch } from "../../../../common";
 import { setIsConnectWalletModalOpen } from "../../../../modules/ui";
 
+const SundownAlertCopy = ({
+  wallet,
+}: {
+  wallet: EnabledWallet | undefined;
+}) => {
+  return (
+    <Typography fontWeight={ 500 } variant="subtitle1">
+      { wallet
+        ? `Your current wallet does not contain this track's stream tokens.
+            Please connect a wallet containing stream tokens for this track`
+        : "Please connect a wallet containing stream tokens for this track." }
+    </Typography>
+  );
+};
+
 export const ConnectWallet = () => {
+  const { webStudioDisableDistributionAndSales } = useFlags();
+
   const dispatch = useAppDispatch();
   const { wallet, disconnect } = useConnectWallet();
 
@@ -20,19 +43,20 @@ export const ConnectWallet = () => {
   return (
     <Stack>
       <Alert>
-        <Typography
-          color={ theme.colors.blue }
-          fontWeight={ 500 }
-          variant="subtitle1"
-        >
-          { wallet
-            ? "Your current wallet does not contain this track's stream " +
-              "tokens. To manage sales on the Marketplace, please first " +
-              "connect a wallet containing stream tokens for this track."
-            : "Please connect a wallet containing stream tokens for " +
-              "this track to manage sales on the Marketplace." }
-        </Typography>
+        { webStudioDisableDistributionAndSales ? (
+          <SundownAlertCopy wallet={ wallet ?? undefined } />
+        ) : (
+          <Typography fontWeight={ 500 } variant="subtitle1">
+            { wallet
+              ? "Your current wallet does not contain this track's stream " +
+                "tokens. To manage sales on the Marketplace, please first " +
+                "connect a wallet containing stream tokens for this track."
+              : "Please connect a wallet containing stream tokens for " +
+                "this track to manage sales on the Marketplace." }
+          </Typography>
+        ) }
       </Alert>
+
       <Button
         gradient="crypto"
         sx={ { mt: 4 } }

--- a/apps/studio/src/pages/home/releases/MarketplaceTab/CreateSale.tsx
+++ b/apps/studio/src/pages/home/releases/MarketplaceTab/CreateSale.tsx
@@ -36,6 +36,7 @@ import { useGetUserWalletSongsThunk } from "../../../../modules/song";
 import { useStartSaleThunk } from "../../../../modules/sale";
 import { useGetProfileQuery } from "../../../../modules/session";
 
+// TODO: Remove once 'webStudioDisableDistributionAndSales' retires.
 const SundownButton = () => (
   <Tooltip title={ <OfficialStatementCTA /> }>
     <span style={ { width: "fit-content" } }>
@@ -46,6 +47,7 @@ const SundownButton = () => (
   </Tooltip>
 );
 
+// TODO: Remove once 'webStudioDisableDistributionAndSales' retires.
 const SundownAlert = ({
   formattedStreamTokensInWallet,
   isOnlyOneTokenAvailable,


### PR DESCRIPTION
# Pull Request — Issue [STUD-578](https://projectnewm.atlassian.net/browse/STUD-578)

## Overview

> This PR gates Marketplace Tab sale creation and copy updates behind the
> `webStudioDisableDistributionAndSales` feature flag while keeping end-sale
> functionality available during the wind-down period.  
> _Context: prevent new stream token sales while still allowing artists to end
> existing sales and access the official statement._

---

## Files Summary

> **Total Changes:** [3 files]  
> _(Counts of added, modified, and deleted files can be seen in the PR diff view.)_

<details>
<summary>Modified (3)</summary>

- **`apps/studio/src/pages/home/releases/MarketplaceTab/ConnectWallet.tsx`**
  - — Add flag-gated alert copy for wallet connection states.
- **`apps/studio/src/pages/home/releases/MarketplaceTab/CreateSale.tsx`**
  - — Gate create-sale form fields and CTA; add disabled tooltip with
    official-statement messaging.
- **`apps/studio/src/pages/home/releases/MarketplaceTab/ActiveSale.tsx`**
  - — Gate active-sale alert copy and button styles for the wind-down period.

</details>

---

## Impact

- Stream token sale creation is disabled when the feature flag is on.
- Marketplace Tab copy is updated for wallet/connect, no-sale, and active-sale
  states under the flag.
- End-sale flow and marketplace link remain available and emphasized.

---

## Testing

- Not run (UI change only).

---

## Related Issues

- Closes [STUD-578](https://projectnewm.atlassian.net/browse/STUD-578).

---

## Dependencies

- No new dependencies.

---

## Demo

### [Figma order](https://www.figma.com/design/zrn01ZR2zFeLiKBebEYI1v/NEWM-Studio---Final-Designs?node-id=17362-2388&m=dev)
<img width="1360" height="684" alt="STUD-758-1" src="https://github.com/user-attachments/assets/96b6d5cc-9a11-4f9e-a6e5-313b25ade7ca" />
<img width="1360" height="679" alt="STUD-758-2" src="https://github.com/user-attachments/assets/7bc380b9-5d41-4c9c-978b-058357f67c7e" />
<img width="1358" height="683" alt="STUD-758-3" src="https://github.com/user-attachments/assets/4f78929d-6486-426d-a14b-9ca4331796dc" />
<img width="1356" height="674" alt="STUD-758-4" src="https://github.com/user-attachments/assets/502e37d4-4527-44a1-a9ba-203482a767eb" />

---

## Additional Notes

- TODO comments note temporary flag-gated UI for later cleanup.

--END--


[STUD-578]: https://projectnewm.atlassian.net/browse/STUD-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[STUD-578]: https://projectnewm.atlassian.net/browse/STUD-578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ